### PR TITLE
manual: add missing line breaks in tpm2_{create,createprimary} pages

### DIFF
--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -52,6 +52,7 @@ password for parent key, optional
 .TP
 \fB\-K ,\-\-pwdk\fR
 password for key, optional
+.TP
 \fB\-g ,\-\-halg\fR
 The hash algorithm to use.
 @ALG_COMMON_INCLUDE@

--- a/man/tpm2_createprimary.8.in
+++ b/man/tpm2_createprimary.8.in
@@ -61,6 +61,7 @@ Hash algorithm used in the computation of the object name.
 Algorithm type for generated key. It supports friendly names like the -g option.
 @ALG_COMMON_INCLUDE@
 @OBJECT_ALG_COMMON_INCLUDE@
+.TP
 \fB\-C\fR,\ \fB\-\-context\fR=[filepath]
 An optional file used to store the object context returned.
 .TP


### PR DESCRIPTION
The manual pages for the tpm2_create and tpm2_createprimary tools are
missing a line break between options, which makes harder to read them.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>