### PR TITLE
autotools: move tools from sbin to bin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ LDADD = \
     $(LIB_COMMON) $(SAPI_LIBS) $(TCTI_SOCK_LIBS) $(TCTI_TABRMD_LIBS) \
     $(TCTI_DEV_LIBS) $(CRYPTO_LIBS)
 
-sbin_PROGRAMS = \
+bin_PROGRAMS = \
     tools/tpm2_create \
     tools/tpm2_createprimary \
     tools/tpm2_load \


### PR DESCRIPTION
sbin is for critical startup utilities. tpm2-tools should
be in regular bin.

Verified by setting DESTDIR=~/tmp and that make install sends
it to /tmp/usr/local/bin.

Fixes: #404

Signed-off-by: William Roberts <william.c.roberts@intel.com>