### PR TITLE
Test password utils

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,12 @@ man8_MANS = \
     man/man8/tpm2_createpolicy.8 \
     man/man8/tpm2_pcrextend.8
 
-man/man8/%.8 : man/%.8.in man/common-options.troff man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff man/sign-alg-common.troff
+MAN_DEPS := man/common-options.troff man/tcti-options.troff \
+           man/tcti-environment.troff man/alg-common.troff \
+           man/hash-alg-common.troff man/object-alg-common.troff \
+           man/sign-alg-common.troff man/password-fmt-common.troff
+
+man/man8/%.8 : man/%.8.in $(MAN_DEPS)
 	rm -f $@
 	mkdir -p man/man8
 if HAVE_TCTI_DEV
@@ -284,6 +289,8 @@ endif
 	    -e '/@OBJECT_ALG_COMMON_INCLUDE@/d' \
 	    -e '/@SIGN_ALG_COMMON_INCLUDE@/r man/sign-alg-common.troff' \
 	    -e '/@SIGN_ALG_COMMON_INCLUDE@/d' \
+	    -e '/@PASSWORD_FORMAT_COMMON_INCLUDE@/r man/password-fmt-common.troff' \
+	    -e '/@PASSWORD_FORMAT_COMMON_INCLUDE@/d' \
 	    < $< >> $@
 
 CLEANFILES = $(man8_MANS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -176,7 +176,8 @@ check_PROGRAMS = \
     test/unit/test_tpm2_header \
     test/unit/test_tpm2_nv_util \
     test/unit/test_tpm2_alg_util \
-    test/unit/test_pcr
+    test/unit/test_pcr \
+    test/unit/test_tpm2_password_util
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -210,6 +211,10 @@ test_unit_test_tpm2_alg_util_SOURCES  = test/unit/test_tpm2_alg_util.c
 test_unit_test_pcr_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_pcr_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_pcr_SOURCES  = test/unit/test_pcr.c
+
+test_unit_test_tpm2_password_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_tpm2_password_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_password_util_SOURCES  = test/unit/test_tpm2_password_util.c
 
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,8 +96,6 @@ lib_libcommon_a_SOURCES = \
     lib/log.h \
     lib/options.c \
     lib/options.h \
-    lib/password_util.c \
-    lib/password_util.h \
     lib/pcr.c \
     lib/pcr.h \
     lib/rc-decode.c \
@@ -107,6 +105,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm2_header.h \
     lib/tpm2_nv_util.c \
     lib/tpm2_nv_util.h \
+    lib/tpm2_password_util.c \
+    lib/tpm2_password_util.h \
     lib/tpm2_policy.c \
     lib/tpm2_policy.h \
     lib/tpm2_util.c \

--- a/lib/tpm2_password_util.c
+++ b/lib/tpm2_password_util.c
@@ -6,7 +6,52 @@
 #include "tpm2_password_util.h"
 #include "tpm2_util.h"
 
+#define HEX_PREFIX "hex:"
+#define HEX_PREFIX_LEN sizeof(HEX_PREFIX) - 1
+
+#define STR_PREFIX "str:"
+#define STR_PREFIX_LEN sizeof(STR_PREFIX) - 1
+
 #define PASSWORD_MAX (sizeof(((TPM2B_DIGEST *)NULL)->t.buffer))
+
+bool tpm2_password_util_from_optarg(const char *password, TPM2B_AUTH *dest) {
+
+    bool is_hex = !strncmp(password, HEX_PREFIX, HEX_PREFIX_LEN);
+    if (!is_hex) {
+
+        /* str may or may not have the str: prefix */
+        bool is_str_prefix = !strncmp(password, STR_PREFIX, STR_PREFIX_LEN);
+        if (is_str_prefix) {
+            password += STR_PREFIX_LEN;
+        }
+
+        /*
+         * Per the man page:
+         * "a return value of size or more means that the output was  truncated."
+         */
+        size_t wrote = snprintf((char *)&dest->t.buffer, BUFFER_SIZE(typeof(*dest), buffer), "%s", password);
+        if (wrote >= BUFFER_SIZE(typeof(*dest), buffer)) {
+            dest->t.size = 0;
+            return false;
+        }
+
+        dest->t.size = wrote;
+
+        return true;
+    }
+
+    /* if it is hex, then skip the prefix */
+    password += HEX_PREFIX_LEN;
+
+    dest->t.size = BUFFER_SIZE(typeof(*dest), buffer);
+    int rc = tpm2_util_hex_to_byte_structure(password, &dest->t.size, dest->t.buffer);
+    if (rc) {
+        dest->t.size = 0;
+        return false;
+    }
+
+    return true;
+}
 
 bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *description,
         TPM2B_AUTH *auth) {

--- a/lib/tpm2_password_util.c
+++ b/lib/tpm2_password_util.c
@@ -3,13 +3,12 @@
 #include <sapi/tpm20.h>
 
 #include "log.h"
-#include "password_util.h"
-
+#include "tpm2_password_util.h"
 #include "tpm2_util.h"
 
 #define PASSWORD_MAX (sizeof(((TPM2B_DIGEST *)NULL)->t.buffer))
 
-bool password_tpm2_util_to_auth(TPM2B_AUTH *password, bool is_hex, const char *description,
+bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *description,
         TPM2B_AUTH *auth) {
 
     if (is_hex) {
@@ -31,7 +30,7 @@ bool password_tpm2_util_to_auth(TPM2B_AUTH *password, bool is_hex, const char *d
     return true;
 }
 
-bool password_tpm2_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest) {
+bool tpm2_password_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest) {
 
     if (!password) {
         LOG_ERR("Please input the %s password!", description);

--- a/lib/tpm2_password_util.c
+++ b/lib/tpm2_password_util.c
@@ -12,8 +12,6 @@
 #define STR_PREFIX "str:"
 #define STR_PREFIX_LEN sizeof(STR_PREFIX) - 1
 
-#define PASSWORD_MAX (sizeof(((TPM2B_DIGEST *)NULL)->t.buffer))
-
 bool tpm2_password_util_from_optarg(const char *password, TPM2B_AUTH *dest) {
 
     bool is_hex = !strncmp(password, HEX_PREFIX, HEX_PREFIX_LEN);
@@ -50,49 +48,5 @@ bool tpm2_password_util_from_optarg(const char *password, TPM2B_AUTH *dest) {
         return false;
     }
 
-    return true;
-}
-
-bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *description,
-        TPM2B_AUTH *auth) {
-
-    if (is_hex) {
-        auth->t.size = sizeof(auth) - 2;
-        /* this routine is safe on overlapping memory areas */
-        if (tpm2_util_hex_to_byte_structure((char *)password->t.buffer, &auth->t.size, auth->t.buffer)
-                != 0) {
-            LOG_ERR("Failed to convert hex format password for %s.",
-                    description);
-            return false;
-        }
-        /*
-         * we only claim sanity on same memory, not overlapping, but well use
-         * memove anyways at the expense of speed.
-         */
-    } else if (password != auth) {
-        memmove(auth, password, sizeof(*auth));
-    }
-    return true;
-}
-
-bool tpm2_password_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest) {
-
-    if (!password) {
-        LOG_ERR("Please input the %s password!", description);
-        return false;
-    }
-
-    if (!dest || !description) {
-        return false;
-    }
-
-    size_t len = strlen(password);
-    if (len >= PASSWORD_MAX) {
-        LOG_ERR("Over-length password for %s. Got %zu expected less than %zu!", description, len, PASSWORD_MAX);
-        return false;
-    }
-
-    dest->t.size = len;
-    snprintf((char *)dest->t.buffer, PASSWORD_MAX, "%s", password);
     return true;
 }

--- a/lib/tpm2_password_util.h
+++ b/lib/tpm2_password_util.h
@@ -4,40 +4,6 @@
 #include <sapi/tpm20.h>
 
 /**
- * Copies a password stored in a TPM2B_AUTH structure, converting from hex if necessary, into
- * another TPM2B_AUTh structure. Source password and auth structures can be the same pointer.
- * @param password
- *  The source password.
- * @param is_hex
- *  True if the password contained in password is hex encoded.
- * @param description
- *  The description of the key used for error reporting.
- * @param auth
- *  The destination auth structure to copy the key into.
- * @return
- *  True on success and False on failure.
- */
-bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *description,
-        TPM2B_AUTH *auth);
-
-/**
- * Copies a C string password into a TPM2B_AUTH structure. It logs an error on failure.
- *
- * Note: Use of a TPM2B_AUTH structure is for proper size allocation reporting and having
- * a size parameter to avoid duplicate strlen() calls.
- *
- * @param password
- *  The C string password to copy.
- * @param description
- *  A description of the password being copied for error reporting purposes.
- * @param dest
- *  The destination TPM2B_AUTH structure.
- * @return
- *  True on success, False on error.
- */
-bool tpm2_password_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest);
-
-/**
  * Convert a password argument to a valid TPM2B_AUTH structure. Passwords can
  * be specified in two forms: string and hex-string and are identified by a
  * prefix of str: and hex: respectively. No prefix assumes the str form.

--- a/lib/tpm2_password_util.h
+++ b/lib/tpm2_password_util.h
@@ -17,7 +17,7 @@
  * @return
  *  True on success and False on failure.
  */
-bool password_tpm2_util_to_auth(TPM2B_AUTH *password, bool is_hex, const char *description,
+bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *description,
         TPM2B_AUTH *auth);
 
 /**
@@ -35,6 +35,6 @@ bool password_tpm2_util_to_auth(TPM2B_AUTH *password, bool is_hex, const char *d
  * @return
  *  True on success, False on error.
  */
-bool password_tpm2_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest);
+bool tpm2_password_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest);
 
 #endif /* SRC_PASSWORD_UTIL_H_ */

--- a/lib/tpm2_password_util.h
+++ b/lib/tpm2_password_util.h
@@ -37,4 +37,34 @@ bool tpm2_password_util_fromhex(TPM2B_AUTH *password, bool is_hex, const char *d
  */
 bool tpm2_password_util_copy_password(const char *password, const char *description, TPM2B_AUTH *dest);
 
+/**
+ * Convert a password argument to a valid TPM2B_AUTH structure. Passwords can
+ * be specified in two forms: string and hex-string and are identified by a
+ * prefix of str: and hex: respectively. No prefix assumes the str form.
+ *
+ * For example, a string can be specified as:
+ * "1234"
+ * "str:1234"
+ *
+ * And a hexstring via:
+ * "hex:1234abcd"
+ *
+ * Strings are copied verbatim to the TPM2B_AUTH buffer without the terminating NULL byte,
+ * Hex strings differ only from strings in that they are converted to a byte array when
+ * storing. At the end of storing, the size field is set to the size of bytes of the
+ * password.
+ *
+ * If your password starts with a hex: prefix and you need to escape it, just use the string
+ * prefix to escape it, like so:
+ * "str:hex:password"
+ *
+ * @param password
+ *  The optarg containing the password string.
+ * @param dest
+ *  The TPM2B_AUTH structure to copy the string into.
+ * @return
+ *  true on success, false on failure.
+ */
+bool tpm2_password_util_from_optarg(const char *password, TPM2B_AUTH *dest);
+
 #endif /* SRC_PASSWORD_UTIL_H_ */

--- a/man/password-fmt-common.troff
+++ b/man/password-fmt-common.troff
@@ -1,0 +1,11 @@
+
+Passwords are interpreted in two forms, string and hex-string. A string password is not
+interpreted, and is directly used for authorization. A hex-string, is converted from
+a hexidecimal form into a byte array form, thus allowing passwords with non-printable
+and/or terminal un-friendly characters.
+
+By default passwords are assumed to be in the string form. Password form is specified
+with special prefix values, they are:
+  str: - Used to indicate it is a raw string. Useful for escaping a password that starts
+         with the "hex:" prefix.
+  hex: - Used when specifying a password in hex string format.

--- a/man/tpm2_activatecredential.8.in
+++ b/man/tpm2_activatecredential.8.in
@@ -60,19 +60,17 @@ Loaded key used to decrypt the the random seed
 filename for keyHandle context
 .TP
 \fB\-P ,\-\-Password\fR
-the handle's password, optional
+the handle's password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-e ,\-\-endorsePasswd\fR
-the endorsement password, optional
+the endorsement password, optional. Follows the same formating guidelines as the handle password option -P.
 .TP
 \fB\-f ,\-\-inFile\fR
 Input file path, containing the two structures  needed by tpm2_activatecredential function 
 .TP
 \fB\-o ,\-\-outFile\fR
 Output file path, record the secret to decrypt  the certificate 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@

--- a/man/tpm2_certify.8.in
+++ b/man/tpm2_certify.8.in
@@ -69,10 +69,12 @@ handle of the key used to sign the attestation  structure
 filename of the key context used to sign the  attestation structure 
 .TP
 \fB\-P ,\-\-pwdo\fR
-the object handle's password, optional
+the object handle's password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-K ,\-\-pwdk\fR
-the keyHandle's password, optional
+the keyHandle's password, optional. Follows the same formatting guidelines
+as the object handle password or -P option.
 @HALG_COMMON_INCLUDE@
 .TP
 \fB\-a ,\-\-attestFile\fR
@@ -80,9 +82,6 @@ output file name, record the attestation structure
 .TP
 \fB\-s ,\-\-sigFile\fR
 output file name, record the signature structure
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@

--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -48,10 +48,11 @@ parent handle
 filename for parent context
 .TP
 \fB\-P ,\-\-pwdp\fR
-password for parent key, optional
+password for parent key, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-K ,\-\-pwdk\fR
-password for key, optional
+password for key, optional. Follows the password formatting of the "password for parent key" option: -P.
 .TP
 \fB\-g ,\-\-halg\fR
 The hash algorithm to use.
@@ -80,9 +81,6 @@ the output file which contains the public key,  optional
 .TP
 \fB\-O ,\-\-opr\fR
 the output file which contains the private key,  optional 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_createprimary.8.in
+++ b/man/tpm2_createprimary.8.in
@@ -48,9 +48,11 @@ Supported options are:
 .TP
 \fB\-P\fR,\ \fB\-\-pwdp\fR=[string]
 Optional authorization string if authorization is required to create object under the specified hierarchy.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-K\fR,\ \fB\-\-pwdk\fR=[string]
-Optional authorization string for the newly created object.
+Optional authorization string for the newly created object. Follows the same password formating guidelines
+as the parent authorization string under the -P option.
 .TP
 \fB\-g\fR,\ \fB\-\-halg\fR
 Hash algorithm used in the computation of the object name.

--- a/man/tpm2_dictionarylockout.8.in
+++ b/man/tpm2_dictionarylockout.8.in
@@ -44,8 +44,9 @@ specifies the tool should operate to setup dictionary-attack-lockout parameters.
 \fB\-c ,\-\-clear-lockout\fR
 specifies the tool should operate to clear dictionary-attack-lockout state.
 .TP
-\fB\-p ,\-\-lockout-passwd\fR
+\fB\-P ,\-\-lockout-passwd\fR
 specifies the password of TPM_RH_LOCKOUT required for both setting up parameters / clearing dictionary-attack-lockout state.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-l ,\-\-lockout-recovery-time\fR
 specifies the wait time in seconds before another TPM_RH_LOCKOUT authentication attempt can be made after a failed authentication. 

--- a/man/tpm2_encryptdecrypt.8.in
+++ b/man/tpm2_encryptdecrypt.8.in
@@ -48,7 +48,8 @@ the symmetric key used for the operation  (encryption/decryption)
 filename of the key context used for the  operation 
 .TP
 \fB\-P ,\-\-pwdk\fR
-the password of key, optional
+the key password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-D ,\-\-decrypt\fR
 the operation type, default NO, optional  YES the operation is decryption   NO the operation is encryption 
@@ -58,9 +59,6 @@ Input file path, containing the data to be  operated
 .TP
 \fB\-o ,\-\-outFile\fR
 Output file path, record the operated data
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_evictcontrol.8.in
+++ b/man/tpm2_evictcontrol.8.in
@@ -54,10 +54,8 @@ filename for object context
 the persistent handle for objectHandle
 .TP
 \fB\-P ,\-\-pwda\fR
-authrization password, optional
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex  format.
+authorization password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-i ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_getpubak.8.in
+++ b/man/tpm2_getpubak.8.in
@@ -51,13 +51,16 @@ default digestAlg is 0xb(SHA256), default signAlg is 0x14(RSASSA) for RSA,
 .SH OPTIONS
 .TP
 \fB\-e ,\-\-endorsePasswd\fR
-specifies current endorsement password  (string,optional,default:NULL). 
+specifies current endorsement password  (string,optional,default:NULL).
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-P ,\-\-akPasswd\fR
-specifies the AK password when created  (string,optional,default:NULL). 
+specifies the AK password when created  (string,optional,default:NULL).
+Same formatting as the endorse password value or -e option.
 .TP
 \fB\-o ,\-\-ownerPasswd\fR
-specifies current owner password  (string,optional,default:NULL). 
+specifies current owner password  (string,optional,default:NULL).
+Same formatting as the endorse password value or -e option.
 .TP
 \fB\-E ,\-\-ekHandle\fR
 specifies the handle of EK (hex).
@@ -83,9 +86,6 @@ specifies the file used to save the public  portion of AK.
 .TP
 \fB\-n ,\-\-akName\fR
 specifies the file used to save the ak name.
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@

--- a/man/tpm2_getpubek.8.in
+++ b/man/tpm2_getpubek.8.in
@@ -51,13 +51,16 @@ http://www.trustedcomputinggroup.org/files/static_page_files/7CAA5687-1A4B-B294-
 .SH OPTIONS
 .TP
 \fB\-e ,\-\-endorsePasswd\fR
-specifies current endorse password (string,  optional, default:NULL). 
+specifies current endorse password (string,  optional, default:NULL).
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-o ,\-\-ownerPasswd\fR
-specifies current owner password (string,  optional, default:NULL). 
+specifies current owner password (string,  optional, default:NULL).
+Same formatting as the endorse password value or -e option.
 .TP
 \fB\-P ,\-\-ekPasswd\fR
-specifies the EK password when created  (string, optional, default:NULL). 
+specifies the EK password when created  (string, optional, default:NULL).
+Same formatting as the endorse password value or -e option.
 .TP
 \fB\-H ,\-\-handle\fR
 specifies the handle used to make EK  persistent (hex). 
@@ -69,9 +72,6 @@ specifies the algorithm type of EK.
 .TP
 \fB\-f ,\-\-file\fR
 specifies the file used to save the public  portion of EK. 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_hmac.8.in
+++ b/man/tpm2_hmac.8.in
@@ -48,7 +48,8 @@ handle for the symmetric signing key providing  the HMAC key
 filename of the key context used for the  operation 
 .TP
 \fB\-P ,\-\-pwdk\fR
-the keyHandle's password, optional
+the keyHandle's password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 \fB\-g ,\-\-halg\fR
 The hash algorithm to use.
 @ALG_COMMON_INCLUDE@
@@ -59,9 +60,6 @@ file containning the data to be HMACed
 .TP
 \fB\-o ,\-\-outfile\fR
 file record the HMAC result
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_load.8.in
+++ b/man/tpm2_load.8.in
@@ -45,7 +45,8 @@ parent handle
 filename for parent context
 .TP
 \fB\-P ,\-\-pwdp\fR
-parent key password, optional
+parent key password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-u ,\-\-pubfile\fR
 The public portion of the object
@@ -58,9 +59,6 @@ Output file name, containing the name  structure
 .TP
 \fB\-C ,\-\-context\fR
 The file to save the object context,  optional 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex  format. 
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_nvdefine.8.in
+++ b/man/tpm2_nvdefine.8.in
@@ -64,12 +64,10 @@ ownerread|ownerwrite|policywrite|nt=0x3
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-I ,\-\-indexPasswd\fR
-specifies the password of NV Index when  created. 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
+specifies the password of NV Index when created. Follows the same formatting guidelines as the handle password or -P option.
 .TP
 \fB\-L ,\-\-policy\-file\fR
 Specifies the policy digest file for policy based authorizations.

--- a/man/tpm2_nvread.8.in
+++ b/man/tpm2_nvread.8.in
@@ -46,15 +46,13 @@ specifies the handle used to authorize:  0x40000001 (TPM_RH_OWNER)   0x4000000C 
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-s ,\-\-size\fR
 specifies the number of octets to read.
 .TP
 \fB\-o ,\-\-offset\fR
 specifies octet offset into the area  This value shall be less than or equal to the   size of the nvIndex data. 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_nvreadlock.8.in
+++ b/man/tpm2_nvreadlock.8.in
@@ -46,6 +46,7 @@ specifies the handle used to authorize:  0x40000001 (TPM_RH_OWNER)   0x4000000C 
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-X ,\-\-passwdInHex\fR
 passwords given by any options are hex format

--- a/man/tpm2_nvrelease.8.in
+++ b/man/tpm2_nvrelease.8.in
@@ -46,9 +46,7 @@ specifies the handle used to authorize:  0x40000001 (TPM_RH_OWNER)   0x4000000C 
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_nvwrite.8.in
+++ b/man/tpm2_nvwrite.8.in
@@ -49,12 +49,10 @@ specifies the handle used to authorize:  0x40000001 (TPM_RH_OWNER)   0x4000000C 
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
 specifies the nv data file.
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_quote.8.in
+++ b/man/tpm2_quote.8.in
@@ -45,7 +45,8 @@ Handle of existing AK
 filename for the existing AK's context
 .TP
 \fB\-P ,\-\-akPassword\fR
-AK handle's Password
+AK handle's Password.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-l ,\-\-idList\fR
 The list of selected PCRs' ids, 0~23

--- a/man/tpm2_rsadecrypt.8.in
+++ b/man/tpm2_rsadecrypt.8.in
@@ -54,7 +54,8 @@ the public portion of RSA key to use for  decryption
 filename of the key context used for the operation
 .TP
 \fB\-P ,\-\-pwdk\fR
-the password of key, optional
+the password of key, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-I ,\-\-inFile\fR
 Input file path, containing the data to be  decrypted 

--- a/man/tpm2_sign.8.in
+++ b/man/tpm2_sign.8.in
@@ -57,7 +57,8 @@ Handle of key that will perform signing
 filename of the key context used for the operation
 .TP
 \fB\-P ,\-\-pwdk\fR
-the password of key, optional
+the password of key, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-g ,\-\-halg\fR
 the hash algorithm used to digest the message.
@@ -72,9 +73,6 @@ the ticket file, containning the validation  structure, optional
 .TP
 \fB\-s ,\-\-sig\fR
 the signature file, record the signature structure
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/man/tpm2_takeownership.8.in
+++ b/man/tpm2_takeownership.8.in
@@ -42,25 +42,28 @@ lockoutAuth, if any passwd option is missing, assume NULL.
 .SH OPTIONS
 .TP
 \fB\-o ,\-\-ownerPasswd\fR
-new Owner authorization value (string,  optional, default:NULL). 
+new Owner authorization value (string,  optional, default:NULL).
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-e ,\-\-endorsePasswd\fR
-new Endorsement authorization value (string,  optional, default:NULL). 
+new Endorsement authorization value (string,  optional, default:NULL).
+Same formatting as the new Owner authorization value or -o option.
 .TP
 \fB\-l ,\-\-lockPasswd\fR
-new Lockout authorization value (string,  optional, default:NULL). 
+new Lockout authorization value (string,  optional, default:NULL).
+Same formatting as the new Owner authorization value or -o option.
 .TP
 \fB\-O ,\-\-oldOwnerPasswd\fR
-old Owner authorization (string, optional,   default:NULL). 
+old Owner authorization (string, optional,   default:NULL).
+Same formatting as the new Owner authorization value or -o option.
 .TP
 \fB\-E ,\-\-oldEndorsePasswd\fR
-old Endorsement authorization (string,  optional, default:NULL). 
+old Endorsement authorization (string,  optional, default:NULL).
+Same formatting as the new Owner authorization value or -o option.
 .TP
 \fB\-L ,\-\-oldLockPasswd\fR
-old Lockout authorization (string, optional,  default:NULL). 
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format
+old Lockout authorization (string, optional,  default:NULL).
+Same formatting as the new Owner authorization value or -o option.
 .TP
 \fB\-c ,\-\-clear\fR
 [-L  [-X]]  clears the 3 authorizations values with  lockout auth. 

--- a/man/tpm2_unseal.8.in
+++ b/man/tpm2_unseal.8.in
@@ -47,13 +47,11 @@ item handle, handle of a loaded data object
 filename for item context
 .TP
 \fB\-P ,\-\-pwdi\fR
-item handle password, optional
+item handle password, optional.
+@PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-o ,\-\-outfile\fR
 Output file name, containing the unsealed data. Defaults to stdout if not specified.
-.TP
-\fB\-X ,\-\-passwdInHex\fR
-passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.

--- a/test/unit/test_tpm2_password_util.c
+++ b/test/unit/test_tpm2_password_util.c
@@ -1,0 +1,122 @@
+//**********************************************************************;
+// Copyright (c) 2017, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <sapi/tpm20.h>
+
+#include "tpm2_util.h"
+#include "tpm2_password_util.h"
+
+static void test_tpm2_password_util_from_optarg_raw_noprefix(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+    bool res = tpm2_password_util_from_optarg("abcd", &dest);
+    assert_true(res);
+    assert_int_equal(dest.t.size, 4);
+    assert_memory_equal(dest.t.buffer, "abcd", 4);
+}
+
+static void test_tpm2_password_util_from_optarg_str_prefix(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+    bool res = tpm2_password_util_from_optarg("str:abcd", &dest);
+    assert_true(res);
+    assert_int_equal(dest.t.size, 4);
+    assert_memory_equal(dest.t.buffer, "abcd", 4);
+}
+
+static void test_tpm2_password_util_from_optarg_hex_prefix(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+    BYTE expected[] = {
+            0x12, 0x34, 0xab, 0xcd
+    };
+
+    bool res = tpm2_password_util_from_optarg("hex:1234abcd", &dest);
+    assert_true(res);
+    assert_int_equal(dest.t.size, sizeof(expected));
+    assert_memory_equal(dest.t.buffer, expected, sizeof(expected));
+}
+
+static void test_tpm2_password_util_from_optarg_str_escaped_hex_prefix(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+
+    bool res = tpm2_password_util_from_optarg("str:hex:1234abcd", &dest);
+    assert_true(res);
+    assert_int_equal(dest.t.size, 12);
+    assert_memory_equal(dest.t.buffer, "hex:1234abcd", 12);
+}
+
+static void test_tpm2_password_util_from_optarg_raw_overlength(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+    char *overlength = "this_password_is_over_64_characters_in_length_and_should_fail_XXX";
+    bool res = tpm2_password_util_from_optarg(overlength, &dest);
+    assert_false(res);
+}
+
+static void test_tpm2_password_util_from_optarg_hex_overlength(void **state) {
+    (void)state;
+
+    TPM2B_AUTH dest;
+    /* 65 hex chars generated via: echo \"`xxd -p -c256 -l65 /dev/urandom`\"\; */
+    char *overlength =
+        "ae6f6fa01589aa7b227bb6a34c7a8e0c273adbcf14195ce12391a5cc12a5c271f62088"
+        "dbfcf1914fdf120da183ec3ad6cc78a2ffd91db40a560169961e3a6d26bf";
+    bool res = tpm2_password_util_from_optarg(overlength, &dest);
+    assert_false(res);
+}
+
+int main(int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    const struct CMUnitTest tests[] = {
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_raw_noprefix),
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_str_prefix),
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_hex_prefix),
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_str_escaped_hex_prefix),
+
+            /* negative testing */
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_raw_overlength),
+            cmocka_unit_test(test_tpm2_password_util_from_optarg_hex_overlength),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -41,11 +41,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 #include "tpm_session.h"
 
@@ -168,13 +168,13 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context,
         .algorithm = TPM_ALG_NULL
     };
 
-    bool result = password_tpm2_util_to_auth(&ctx->password.hmac, ctx->hexPasswd,
+    bool result = tpm2_password_util_fromhex(&ctx->password.hmac, ctx->hexPasswd,
             "handlePasswd", &ctx->password.hmac);
     if (!result) {
         return false;
     }
 
-    result = password_tpm2_util_to_auth(&ctx->endorse_password.hmac, ctx->hexPasswd,
+    result = tpm2_password_util_fromhex(&ctx->endorse_password.hmac, ctx->hexPasswd,
             "endorsePasswd", &ctx->endorse_password.hmac);
     if (!result) {
         return false;
@@ -276,7 +276,7 @@ static bool init(int argc, char *argv[], tpm_activatecred_ctx *ctx) {
             break;
         case 'P':
             ctx->password.hmac.t.size = sizeof(ctx->password.hmac.t) - 2;
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->password.hmac);
             if (!result) {
                 return false;
@@ -284,7 +284,7 @@ static bool init(int argc, char *argv[], tpm_activatecred_ctx *ctx) {
             //P_flag = 1;
             break;
         case 'e':
-            result = password_tpm2_util_copy_password(optarg, "endorse password",
+            result = tpm2_password_util_copy_password(optarg, "endorse password",
                     &ctx->endorse_password.hmac);
             if (!result) {
                 return false;

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -41,7 +41,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -59,7 +59,6 @@ struct tpm_activatecred_ctx {
 
     TPM2B_ID_OBJECT credentialBlob;
     TPM2B_ENCRYPTED_SECRET secret;
-    bool hexPasswd;
 
     TPMS_AUTH_COMMAND password;
     TPMS_AUTH_COMMAND endorse_password;
@@ -168,18 +167,6 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context,
         .algorithm = TPM_ALG_NULL
     };
 
-    bool result = tpm2_password_util_fromhex(&ctx->password.hmac, ctx->hexPasswd,
-            "handlePasswd", &ctx->password.hmac);
-    if (!result) {
-        return false;
-    }
-
-    result = tpm2_password_util_fromhex(&ctx->endorse_password.hmac, ctx->hexPasswd,
-            "endorsePasswd", &ctx->endorse_password.hmac);
-    if (!result) {
-        return false;
-    }
-
     SESSION *session = NULL;
     UINT32 rval = tpm_session_start_auth_with_params(sapi_context, &session,
             TPM_RH_NULL, 0, TPM_RH_NULL, 0, &nonceCaller, &encryptedSalt,
@@ -275,18 +262,17 @@ static bool init(int argc, char *argv[], tpm_activatecred_ctx *ctx) {
             C_flag = 1;
             break;
         case 'P':
-            ctx->password.hmac.t.size = sizeof(ctx->password.hmac.t) - 2;
-            result = tpm2_password_util_copy_password(optarg, "handle password",
-                    &ctx->password.hmac);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->password.hmac);
             if (!result) {
+                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
                 return false;
             }
             //P_flag = 1;
             break;
         case 'e':
-            result = tpm2_password_util_copy_password(optarg, "endorse password",
-                    &ctx->endorse_password.hmac);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->endorse_password.hmac);
             if (!result) {
+                LOG_ERR("Invalid endorse password, got\"%s\"", optarg);
                 return false;
             }
             break;
@@ -302,9 +288,6 @@ static bool init(int argc, char *argv[], tpm_activatecred_ctx *ctx) {
         case 'o':
             ctx->file.output = optarg;
             o_flag = 1;
-            break;
-        case 'X':
-            ctx->hexPasswd = true;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -38,7 +38,7 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "tpm2_util.h"
 #include "log.h"
 #include "files.h"
@@ -191,12 +191,11 @@ static bool certify_and_save_data(tpm_certify_ctx *ctx) {
 static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
 
     bool result;
-    bool is_hex_password = false;
 
     char *context_file = NULL;
     char *context_key_file = NULL;
 
-    const char *optstring = "H:k:P:K:g:a:s:C:c:X";
+    const char *optstring = "H:k:P:K:g:a:s:C:c:";
     static struct option long_options[] = {
       {"objectHandle", required_argument, NULL, 'H'},
       {"keyHandle",    required_argument, NULL, 'k'},
@@ -207,7 +206,6 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
       {"sigFile",      required_argument, NULL, 's'},
       {"objContext",   required_argument, NULL, 'C'},
       {"keyContext",   required_argument, NULL, 'c'},
-      {"passwdInHex",  no_argument,       NULL, 'X'},
       {NULL,           no_argument,       NULL, '\0'}
     };
 
@@ -257,17 +255,17 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             flags.k = 1;
             break;
         case 'P':
-            result = tpm2_password_util_copy_password(optarg, "object handle",
-                    &ctx->cmd_auth[0].hmac);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->cmd_auth[0].hmac);
             if (!result) {
+                LOG_ERR("Invalid object key password, got\"%s\"", optarg);
                 return false;
             }
             flags.P = 1;
             break;
         case 'K':
-            result = tpm2_password_util_copy_password(optarg, "key handle",
-                    &ctx->cmd_auth[1].hmac);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->cmd_auth[1].hmac);
             if (!result) {
+                LOG_ERR("Invalid key handle password, got\"%s\"", optarg);
                 return false;
             }
             flags.K = 1;
@@ -311,9 +309,6 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             context_file = optarg;
             flags.C = 1;
             break;
-        case 'X':
-            is_hex_password = true;
-            break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
             result = false;
@@ -331,19 +326,6 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
 
     if (!(flags.H || flags.C) && (flags.k || flags.c) && (flags.g) && (flags.a)
             && (flags.s)) {
-        return false;
-    }
-
-    /* convert a hex passwords if needed */
-    result = tpm2_password_util_fromhex(&ctx->cmd_auth[0].hmac, is_hex_password,
-            "object handle", &ctx->cmd_auth[0].hmac);
-    if (!result) {
-        return false;
-    }
-
-    result = tpm2_password_util_fromhex(&ctx->cmd_auth[1].hmac, is_hex_password,
-            "key handle", &ctx->cmd_auth[1].hmac);
-    if (!result) {
         return false;
     }
 
@@ -374,22 +356,12 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     (void)envp;
 
     tpm_certify_ctx ctx = {
-            .cmd_auth = {
-                {
-                    .sessionHandle = TPM_RS_PW,
-                    .nonce = TPM2B_EMPTY_INIT,
-                    .hmac = TPM2B_EMPTY_INIT,
-                    .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
-            }, // [0]
-                {
-                    .sessionHandle = TPM_RS_PW,
-                    .nonce = TPM2B_EMPTY_INIT,
-                    .hmac = TPM2B_EMPTY_INIT,
-                    .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
-                }  // [1]
-            },
-            .file_path = { .attest = NULL, .sig = NULL },
-            .sapi_context = sapi_context
+        .cmd_auth = {
+            TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+            TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+        },
+        .file_path = { .attest = NULL, .sig = NULL },
+        .sapi_context = sapi_context
     };
 
     bool result = init(argc, argv, &ctx);

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -38,12 +38,12 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_alg_util.h"
 
 typedef struct tpm_certify_ctx tpm_certify_ctx;
@@ -257,7 +257,7 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             flags.k = 1;
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "object handle",
+            result = tpm2_password_util_copy_password(optarg, "object handle",
                     &ctx->cmd_auth[0].hmac);
             if (!result) {
                 return false;
@@ -265,7 +265,7 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             flags.P = 1;
             break;
         case 'K':
-            result = password_tpm2_util_copy_password(optarg, "key handle",
+            result = tpm2_password_util_copy_password(optarg, "key handle",
                     &ctx->cmd_auth[1].hmac);
             if (!result) {
                 return false;
@@ -335,13 +335,13 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
     }
 
     /* convert a hex passwords if needed */
-    result = password_tpm2_util_to_auth(&ctx->cmd_auth[0].hmac, is_hex_password,
+    result = tpm2_password_util_fromhex(&ctx->cmd_auth[0].hmac, is_hex_password,
             "object handle", &ctx->cmd_auth[0].hmac);
     if (!result) {
         return false;
     }
 
-    result = password_tpm2_util_to_auth(&ctx->cmd_auth[1].hmac, is_hex_password,
+    result = tpm2_password_util_fromhex(&ctx->cmd_auth[1].hmac, is_hex_password,
             "key handle", &ctx->cmd_auth[1].hmac);
     if (!result) {
         return false;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -41,7 +41,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "tpm2_util.h"
 #include "files.h"
 #include "main.h"
@@ -56,8 +56,6 @@ TPMS_AUTH_COMMAND sessionData = {
     .hmac = TPM2B_EMPTY_INIT,
     .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
 };
-
-bool hexPasswd = false;
 
 int setAlg(TPMI_ALG_PUBLIC type,TPMI_ALG_HASH nameAlg,TPM2B_PUBLIC *inPublic, int I_flag, bool is_policy_enforced)
 {
@@ -168,29 +166,7 @@ int create(TPMI_DH_OBJECT parentHandle, TPM2B_PUBLIC *inPublic, TPM2B_SENSITIVE_
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    if (sessionData.hmac.t.size > 0 && hexPasswd)
-    {
-        sessionData.hmac.t.size = sizeof(sessionData.hmac) - 2;
-        if (tpm2_util_hex_to_byte_structure((char *)sessionData.hmac.t.buffer,
-                              &sessionData.hmac.t.size,
-                              sessionData.hmac.t.buffer) != 0)
-        {
-            printf( "Failed to convert Hex format password for parent Passwd.\n");
-            return -1;
-        }
-    }
 
-    if (inSensitive->t.sensitive.userAuth.t.size > 0 && hexPasswd)
-    {
-        inSensitive->t.sensitive.userAuth.t.size = sizeof(inSensitive->t.sensitive.userAuth) - 2;
-        if (tpm2_util_hex_to_byte_structure((char *)inSensitive->t.sensitive.userAuth.t.buffer,
-                              &inSensitive->t.sensitive.userAuth.t.size,
-                              inSensitive->t.sensitive.userAuth.t.buffer) != 0)
-        {
-            printf( "Failed to convert Hex format password for object Passwd.\n");
-            return -1;
-        }
-    }
     inSensitive->t.size = inSensitive->t.sensitive.userAuth.b.size + 2;
 
     if(setAlg(type, nameAlg, inPublic, I_flag, is_policy_enforced))
@@ -256,7 +232,7 @@ execute_tool (int              argc,
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     int opt = -1;
-    const char *optstring = "H:P:K:g:G:A:I:L:o:O:c:S:XE";
+    const char *optstring = "H:P:K:g:G:A:I:L:o:O:c:S:E";
     static struct option long_options[] = {
       {"parent",1,NULL,'H'},
       {"pwdp",1,NULL,'P'},
@@ -270,7 +246,6 @@ execute_tool (int              argc,
       {"opu",1,NULL,'o'},
       {"opr",1,NULL,'O'},
       {"contextParent",1,NULL,'c'},
-      {"passwdInHex",0,NULL,'X'},
       {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };
@@ -304,20 +279,22 @@ execute_tool (int              argc,
             H_flag = 1;
             break;
 
-        case 'P':
-            if(!tpm2_password_util_copy_password(optarg, "Parent key password", &sessionData.hmac))
-            {
+        case 'P': {
+            bool res = tpm2_password_util_from_optarg(optarg, &sessionData.hmac);
+            if (!res) {
+                LOG_ERR("Invalid parent key password, got\"%s\"", optarg);
                 return 1;
             }
             P_flag = 1;
-            break;
-        case 'K':
-            if(!tpm2_password_util_copy_password(optarg, "Key password", &inSensitive.t.sensitive.userAuth))
-            {
+        } break;
+        case 'K': {
+            bool res = tpm2_password_util_from_optarg(optarg, &inSensitive.t.sensitive.userAuth);
+            if (!res) {
+                LOG_ERR("Invalid key password, got\"%s\"", optarg);
                 return 1;
             }
             K_flag = 1;
-            break;
+        } break;
         case 'g':
             nameAlg = tpm2_alg_util_from_optarg(optarg);
             if(nameAlg == TPM_ALG_ERROR)
@@ -402,9 +379,6 @@ execute_tool (int              argc,
             }
             printf("contextParentFile = %s\n", contextParentFilePath);
             c_flag = 1;
-            break;
-        case 'X':
-            hexPasswd = true;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -41,8 +41,8 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "tpm2_util.h"
-#include "password_util.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
@@ -305,14 +305,14 @@ execute_tool (int              argc,
             break;
 
         case 'P':
-            if(!password_tpm2_util_copy_password(optarg, "Parent key password", &sessionData.hmac))
+            if(!tpm2_password_util_copy_password(optarg, "Parent key password", &sessionData.hmac))
             {
                 return 1;
             }
             P_flag = 1;
             break;
         case 'K':
-            if(!password_tpm2_util_copy_password(optarg, "Key password", &inSensitive.t.sensitive.userAuth))
+            if(!tpm2_password_util_copy_password(optarg, "Key password", &inSensitive.t.sensitive.userAuth))
             {
                 return 1;
             }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -42,12 +42,12 @@
 #include <sapi/tpm20.h>
 #include <tcti/tcti_socket.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "tpm2_util.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_alg_util.h"
 
 TPMS_AUTH_COMMAND sessionData = {
@@ -243,7 +243,7 @@ execute_tool (int               argc,
             break;
 
         case 'P':
-            if(!password_tpm2_util_copy_password(optarg, "parent key",
+            if(!tpm2_password_util_copy_password(optarg, "parent key",
                     &sessionData.hmac))
             {
                 return 1;
@@ -252,7 +252,7 @@ execute_tool (int               argc,
             P_flag = 1;
             break;
         case 'K':
-            if(!password_tpm2_util_copy_password(optarg, "new key",
+            if(!tpm2_password_util_copy_password(optarg, "new key",
                     &inSensitive.t.sensitive.userAuth))
             {
                 return 1;

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -38,10 +38,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct dictionarylockout_ctx dictionarylockout_ctx;
@@ -72,7 +72,7 @@ bool dictionary_lockout_reset_and_parameter_setup(dictionarylockout_ctx *ctx) {
     TSS2_SYS_CMD_AUTHS sessionsData = { .cmdAuths = &sessionDataArray[0],
             .cmdAuthsCount = 1 };
     if (ctx->use_passwd) {
-        bool result = password_tpm2_util_to_auth(&ctx->lockout_passwd, false,
+        bool result = tpm2_password_util_fromhex(&ctx->lockout_passwd, false,
                 "Lockout Password", &sessionData.hmac);
         if (!result) {
             return false;
@@ -143,7 +143,7 @@ static bool init(int argc, char *argv[], dictionarylockout_ctx *ctx) {
             ctx->setup_parameters = true;
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "Lockout Password",
+            result = tpm2_password_util_copy_password(optarg, "Lockout Password",
                     &ctx->lockout_passwd);
             if (!result) {
                 return false;

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -38,7 +38,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
@@ -49,35 +49,20 @@ struct dictionarylockout_ctx {
     UINT32 max_tries;
     UINT32 recovery_time;
     UINT32 lockout_recovery_time;
-    TPM2B_AUTH lockout_passwd;
     bool clear_lockout;
     bool setup_parameters;
     bool use_passwd;
     TSS2_SYS_CONTEXT *sapi_context;
-    TPMI_SH_AUTH_SESSION auth_session_handle;
-    bool is_session_based_auth;
+    TPMS_AUTH_COMMAND session_data;
 };
 
 bool dictionary_lockout_reset_and_parameter_setup(dictionarylockout_ctx *ctx) {
 
-    //Command Auths
-    TPMS_AUTH_COMMAND sessionData = { .sessionHandle = TPM_RS_PW,
-            .nonce.t.size = 0, .hmac.t.size = 0, .sessionAttributes.val = 0 };
-    if (ctx->is_session_based_auth) {
-        sessionData.sessionHandle = ctx->auth_session_handle;
-    }
     TPMS_AUTH_COMMAND *sessionDataArray[1];
-    sessionDataArray[0] = &sessionData;
+    sessionDataArray[0] = &ctx->session_data;
 
     TSS2_SYS_CMD_AUTHS sessionsData = { .cmdAuths = &sessionDataArray[0],
             .cmdAuthsCount = 1 };
-    if (ctx->use_passwd) {
-        bool result = tpm2_password_util_fromhex(&ctx->lockout_passwd, false,
-                "Lockout Password", &sessionData.hmac);
-        if (!result) {
-            return false;
-        }
-    }
 
     //Response Auths
     TPMS_AUTH_RESPONSE *sessionDataOutArray[1], sessionDataOut;
@@ -143,9 +128,9 @@ static bool init(int argc, char *argv[], dictionarylockout_ctx *ctx) {
             ctx->setup_parameters = true;
             break;
         case 'P':
-            result = tpm2_password_util_copy_password(optarg, "Lockout Password",
-                    &ctx->lockout_passwd);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
             if (!result) {
+                LOG_ERR("Invalid lockout password, got\"%s\"", optarg);
                 return false;
             }
             ctx->use_passwd = true;
@@ -182,12 +167,11 @@ static bool init(int argc, char *argv[], dictionarylockout_ctx *ctx) {
             }
             break;
         case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->auth_session_handle)) {
+             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
                  LOG_ERR("Could not convert session handle to number, got: \"%s\"",
                          optarg);
                  return false;
              }
-             ctx->is_session_based_auth = true;
              break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
@@ -226,7 +210,8 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
         .lockout_recovery_time = 0, 
         .clear_lockout = false,
         .setup_parameters = false, 
-        .use_passwd = true, 
+        .use_passwd = true,
+        .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
         .sapi_context = sapi_context
     };
 

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -40,11 +40,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_encrypt_decrypt_ctx tpm_encrypt_decrypt_ctx;
@@ -149,7 +149,7 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
             flags.k = 1;
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "key", &ctx->session_data.hmac);
+            result = tpm2_password_util_copy_password(optarg, "key", &ctx->session_data.hmac);
             if (!result) {
                 return result;
             }
@@ -224,7 +224,7 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
         }
     }
 
-    return password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd, "key",
+    return tpm2_password_util_fromhex(&ctx->session_data.hmac, is_hex_passwd, "key",
             &ctx->session_data.hmac);
 }
 

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -41,11 +41,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_evictcontrol_ctx tpm_evictcontrol_ctx;
@@ -157,7 +157,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = password_tpm2_util_copy_password(optarg, "authenticating",
+            bool result = tpm2_password_util_copy_password(optarg, "authenticating",
                     &ctx->session_data.hmac);
             if (!result) {
                 return false;
@@ -196,7 +196,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
         return false;
     }
 
-    bool result = password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd,
+    bool result = tpm2_password_util_fromhex(&ctx->session_data.hmac, is_hex_passwd,
             "authenticating", &ctx->session_data.hmac);
     if (!result) {
         return false;

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -39,7 +39,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -59,7 +59,6 @@ struct getpubak_context {
         TPM2B_AUTH ak;
         TPM2B_AUTH owner;
     } passwords;
-    bool hexPasswd;
     char *outputFile;
     char *aknameFile;
     TPM_ALG_ID algorithmType;
@@ -238,22 +237,14 @@ static bool create_ak(getpubak_context *ctx) {
     inSensitive.t.size = inSensitive.t.sensitive.userAuth.b.size + 2;
     creation_pcr.count = 0;
 
-    bool result = tpm2_password_util_fromhex(&ctx->passwords.ak, ctx->hexPasswd, "AK",
-            &inSensitive.t.sensitive.userAuth);
+    memcpy(&inSensitive.t.sensitive.userAuth, &ctx->passwords.ak, sizeof(ctx->passwords.ak));
+
+    bool result = set_key_algorithm(ctx, &inPublic);
     if (!result) {
         return false;
     }
 
-    result = set_key_algorithm(ctx, &inPublic);
-    if (!result) {
-        return false;
-    }
-
-    result = tpm2_password_util_fromhex(&ctx->passwords.endorse, ctx->hexPasswd,
-            "endorse", &session_data.hmac);
-    if (!result) {
-        return false;
-    }
+    memcpy(&session_data.hmac, &ctx->passwords.endorse, sizeof(ctx->passwords.endorse));
 
     SESSION *session = NULL;
     UINT32 rval = tpm_session_start_auth_with_params(ctx->sapi_context, &session, TPM_RH_NULL, 0, TPM_RH_NULL, 0,
@@ -302,11 +293,7 @@ static bool create_ak(getpubak_context *ctx) {
     session_data.sessionAttributes.continueSession = 0;
     session_data.hmac.t.size = 0;
 
-    result = tpm2_password_util_fromhex(&ctx->passwords.endorse, ctx->hexPasswd,
-            "endorse", &session_data.hmac);
-    if (!result) {
-        return false;
-    }
+    memcpy(&session_data.hmac, &ctx->passwords.endorse, sizeof(ctx->passwords.endorse));
 
     rval = tpm_session_start_auth_with_params(ctx->sapi_context, &session, TPM_RH_NULL, 0, TPM_RH_NULL, 0,
             &nonce_caller, &encrypted_salt, TPM_SE_POLICY, &symmetric,
@@ -365,11 +352,7 @@ static bool create_ak(getpubak_context *ctx) {
     session_data.hmac.t.size = 0;
 
     // use the owner auth here.
-    result = tpm2_password_util_fromhex(&ctx->passwords.owner, ctx->hexPasswd, "owner",
-            &session_data.hmac);
-    if (!result) {
-        return false;
-    }
+    memcpy(&session_data.hmac, &ctx->passwords.owner, sizeof(ctx->passwords.owner));
 
     rval = Tss2_Sys_EvictControl(ctx->sapi_context, TPM_RH_OWNER, loaded_sha1_key_handle,
             &sessions_data, ctx->persistent_handle.ak, &sessions_data_out);
@@ -411,7 +394,6 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
         { "akPasswd"   , required_argument, NULL, 'P' },
         { "file"       , required_argument, NULL, 'f' },
         { "akName"     , required_argument, NULL, 'n' },
-        { "passwdInHex", no_argument,       NULL, 'X' },
         { NULL         , no_argument,       NULL,  0  },
     };
 
@@ -422,7 +404,7 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
 
     int opt;
     bool result;
-    while ((opt = getopt_long(argc, argv, "o:E:e:k:g:D:s:P:f:n:Xp:", opts, NULL))
+    while ((opt = getopt_long(argc, argv, "o:E:e:k:g:D:s:P:f:n:p:", opts, NULL))
             != -1) {
         switch (opt) {
         case 'E':
@@ -461,22 +443,23 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
             }
             break;
         case 'o':
-            result = tpm2_password_util_copy_password(optarg, "owner",
-                    &ctx->passwords.owner);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.owner);
             if (!result) {
+                LOG_ERR("Invalid owner password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'e':
-            result = tpm2_password_util_copy_password(optarg, "endorse",
-                    &ctx->passwords.endorse);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.endorse);
             if (!result) {
+                LOG_ERR("Invalid endorse password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'P':
-            result = tpm2_password_util_copy_password(optarg, "AK", &ctx->passwords.ak);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.ak);
             if (!result) {
+                LOG_ERR("Invalid AK password, got\"%s\"", optarg);
                 return false;
             }
             break;
@@ -495,9 +478,6 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
                 return false;
             }
             ctx->aknameFile = optarg;
-            break;
-        case 'X':
-            ctx->hexPasswd = true;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
@@ -521,10 +501,14 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     (void)envp;
 
     getpubak_context ctx = {
-            .hexPasswd = false,
             .algorithmType = TPM_ALG_RSA,
             .digestAlg = TPM_ALG_SHA256,
             .signAlg = TPM_ALG_NULL,
+            .passwords = {
+                .endorse = TPM2B_EMPTY_INIT,
+                .ak      = TPM2B_EMPTY_INIT,
+                .owner   = TPM2B_EMPTY_INIT,
+            },
             .sapi_context = sapi_context
     };
 

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -39,11 +39,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 #include "tpm_session.h"
 #include "tpm2_alg_util.h"
@@ -238,7 +238,7 @@ static bool create_ak(getpubak_context *ctx) {
     inSensitive.t.size = inSensitive.t.sensitive.userAuth.b.size + 2;
     creation_pcr.count = 0;
 
-    bool result = password_tpm2_util_to_auth(&ctx->passwords.ak, ctx->hexPasswd, "AK",
+    bool result = tpm2_password_util_fromhex(&ctx->passwords.ak, ctx->hexPasswd, "AK",
             &inSensitive.t.sensitive.userAuth);
     if (!result) {
         return false;
@@ -249,7 +249,7 @@ static bool create_ak(getpubak_context *ctx) {
         return false;
     }
 
-    result = password_tpm2_util_to_auth(&ctx->passwords.endorse, ctx->hexPasswd,
+    result = tpm2_password_util_fromhex(&ctx->passwords.endorse, ctx->hexPasswd,
             "endorse", &session_data.hmac);
     if (!result) {
         return false;
@@ -302,7 +302,7 @@ static bool create_ak(getpubak_context *ctx) {
     session_data.sessionAttributes.continueSession = 0;
     session_data.hmac.t.size = 0;
 
-    result = password_tpm2_util_to_auth(&ctx->passwords.endorse, ctx->hexPasswd,
+    result = tpm2_password_util_fromhex(&ctx->passwords.endorse, ctx->hexPasswd,
             "endorse", &session_data.hmac);
     if (!result) {
         return false;
@@ -365,7 +365,7 @@ static bool create_ak(getpubak_context *ctx) {
     session_data.hmac.t.size = 0;
 
     // use the owner auth here.
-    result = password_tpm2_util_to_auth(&ctx->passwords.owner, ctx->hexPasswd, "owner",
+    result = tpm2_password_util_fromhex(&ctx->passwords.owner, ctx->hexPasswd, "owner",
             &session_data.hmac);
     if (!result) {
         return false;
@@ -461,21 +461,21 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
             }
             break;
         case 'o':
-            result = password_tpm2_util_copy_password(optarg, "owner",
+            result = tpm2_password_util_copy_password(optarg, "owner",
                     &ctx->passwords.owner);
             if (!result) {
                 return false;
             }
             break;
         case 'e':
-            result = password_tpm2_util_copy_password(optarg, "endorse",
+            result = tpm2_password_util_copy_password(optarg, "endorse",
                     &ctx->passwords.endorse);
             if (!result) {
                 return false;
             }
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "AK", &ctx->passwords.ak);
+            result = tpm2_password_util_copy_password(optarg, "AK", &ctx->passwords.ak);
             if (!result) {
                 return false;
             }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -38,10 +38,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 #include "tpm2_alg_util.h"
 
@@ -182,13 +182,13 @@ static bool create_ek_handle(getpubek_context *ctx) {
     sessionsDataOut.rspAuthsCount = 1;
     sessionsData.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->passwords.endorse,
+    bool result = tpm2_password_util_fromhex(&ctx->passwords.endorse,
             ctx->passwords.is_hex, "endorse", &sessionData.hmac);
     if (!result) {
         return false;
     }
 
-    result = password_tpm2_util_to_auth(&ctx->passwords.ek, ctx->passwords.is_hex,
+    result = tpm2_password_util_fromhex(&ctx->passwords.ek, ctx->passwords.is_hex,
             "ek", &inSensitive.t.sensitive.userAuth);
     if (!result) {
         return false;
@@ -219,7 +219,7 @@ static bool create_ek_handle(getpubek_context *ctx) {
 
     // To make EK persistent, use own auth
     sessionData.hmac.t.size = 0;
-    result = password_tpm2_util_to_auth(&ctx->passwords.owner, ctx->passwords.is_hex,
+    result = tpm2_password_util_fromhex(&ctx->passwords.owner, ctx->passwords.is_hex,
             "owner", &sessionData.hmac);
     if (!result) {
         return false;
@@ -296,21 +296,21 @@ static bool init(int argc, char *argv[], char *envp[], getpubek_context *ctx) {
             break;
 
         case 'e':
-            result = password_tpm2_util_copy_password(optarg, "endorsement password",
+            result = tpm2_password_util_copy_password(optarg, "endorsement password",
                     &ctx->passwords.endorse);
             if (!result) {
                 return false;
             }
             break;
         case 'o':
-            result = password_tpm2_util_copy_password(optarg, "owner password",
+            result = tpm2_password_util_copy_password(optarg, "owner password",
                     &ctx->passwords.owner);
             if (!result) {
                 return false;
             }
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "EK password", &ctx->passwords.ek);
+            result = tpm2_password_util_copy_password(optarg, "EK password", &ctx->passwords.ek);
             if (!result) {
                 return false;
             }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -38,7 +38,6 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -38,11 +38,11 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_random_ctx tpm_random_ctx;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -38,12 +38,12 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_alg_util.h"
 
 typedef struct tpm_hmac_ctx tpm_hmac_ctx;
@@ -159,7 +159,7 @@ static bool init(int argc, char *argv[], tpm_hmac_ctx *ctx) {
             flags.k = 1;
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "key handle",
+            result = tpm2_password_util_copy_password(optarg, "key handle",
                     &ctx->session_data.hmac);
             if (!result) {
                 return false;
@@ -242,7 +242,7 @@ static bool init(int argc, char *argv[], tpm_hmac_ctx *ctx) {
     }
 
     /* convert a hex password if needed */
-    return password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd,
+    return tpm2_password_util_fromhex(&ctx->session_data.hmac, is_hex_passwd,
             "key handle", &ctx->session_data.hmac);
 }
 

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -41,7 +41,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "log.h"
 #include "tpm2_util.h"
 #include "files.h"
@@ -55,7 +55,6 @@ TPMS_AUTH_COMMAND sessionData = {
         .hmac = TPM2B_EMPTY_INIT,
         .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
 };
-bool hexPasswd = false;
 
 int
 load (TSS2_SYS_CONTEXT *sapi_context,
@@ -129,7 +128,7 @@ execute_tool (int              argc,
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     int opt = -1;
-    const char *optstring = "H:P:u:r:n:C:c:S:X";
+    const char *optstring = "H:P:u:r:n:C:c:S:";
     static struct option long_options[] = {
       {"parent",1,NULL,'H'},
       {"pwdp",1,NULL,'P'},
@@ -138,7 +137,6 @@ execute_tool (int              argc,
       {"name",1,NULL,'n'},
       {"context",1,NULL,'C'},
       {"contextParent",1,NULL,'c'},
-      {"passwdInHex",0,NULL,'X'},
       {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };
@@ -146,7 +144,6 @@ execute_tool (int              argc,
     int returnVal = 0;
     int flagCnt = 0;
     int H_flag = 0,
-        P_flag = 0,
         u_flag = 0,
         r_flag = 0,
         c_flag = 0,
@@ -165,13 +162,13 @@ execute_tool (int              argc,
             printf("\nparentHandle: 0x%x\n\n",parentHandle);
             H_flag = 1;
             break;
-        case 'P':
-            if(!tpm2_password_util_copy_password(optarg, "parent key", &sessionData.hmac))
-            {
+        case 'P': {
+            bool res = tpm2_password_util_from_optarg(optarg, &sessionData.hmac);
+            if (!res) {
+                LOG_ERR("Invalid parent key password, got\"%s\"", optarg);
                 return 1;
             }
-            P_flag = 1;
-            break;
+        } break;
 
         case 'u':
             size = sizeof(inPublic);
@@ -215,9 +212,6 @@ execute_tool (int              argc,
             printf("contextFile = %s\n", contextFile);
             C_flag = 1;
             break;
-        case 'X':
-            hexPasswd = true;
-            break;
         case 'S':
              if (!tpm2_util_string_to_uint32(optarg, &sessionData.sessionHandle)) {
                  LOG_ERR("Could not convert session handle to number, got: \"%s\"",
@@ -236,16 +230,6 @@ execute_tool (int              argc,
             return 1;
         }
     };
-
-    if (P_flag && hexPasswd) {
-        int rc = tpm2_util_hex_to_byte_structure((char *)sessionData.hmac.t.buffer,
-                          &sessionData.hmac.t.size,
-                          sessionData.hmac.t.buffer);
-        if (rc) {
-            LOG_ERR("Could not convert password to hex!");
-            return 1;
-        }
-    }
 
     flagCnt = H_flag + u_flag +r_flag + n_flag + c_flag;
     if(flagCnt == 4 && (H_flag == 1 || c_flag == 1) && u_flag == 1 && r_flag == 1 && n_flag == 1)

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -41,9 +41,9 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "tpm2_util.h"
-#include "password_util.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
@@ -166,7 +166,7 @@ execute_tool (int              argc,
             H_flag = 1;
             break;
         case 'P':
-            if(!password_tpm2_util_copy_password(optarg, "parent key", &sessionData.hmac))
+            if(!tpm2_password_util_copy_password(optarg, "parent key", &sessionData.hmac))
             {
                 return 1;
             }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -38,11 +38,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_util.h"
 
@@ -93,7 +93,7 @@ static int nv_space_define(tpm_nvdefine_ctx *ctx) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->handlePasswd, ctx->hexPasswd,
+    bool result = tpm2_password_util_fromhex(&ctx->handlePasswd, ctx->hexPasswd,
             "handle password", &session_data.hmac);
     if (!result) {
         return false;
@@ -117,7 +117,7 @@ static int nv_space_define(tpm_nvdefine_ctx *ctx) {
     public_info.t.nvPublic.dataSize = ctx->size;
 
     TPM2B_AUTH nvAuth;
-    result = password_tpm2_util_to_auth(&ctx->indexPasswd, ctx->hexPasswd,
+    result = tpm2_password_util_fromhex(&ctx->indexPasswd, ctx->hexPasswd,
             "index password", &nvAuth);
     if (!result) {
         return false;
@@ -190,7 +190,7 @@ static bool init(int argc, char* argv[], tpm_nvdefine_ctx *ctx) {
             }
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->handlePasswd);
             if (!result) {
                 return false;
@@ -216,7 +216,7 @@ static bool init(int argc, char* argv[], tpm_nvdefine_ctx *ctx) {
             }
             break;
         case 'I':
-            result = password_tpm2_util_copy_password(optarg, "index password",
+            result = tpm2_password_util_copy_password(optarg, "index password",
                     &ctx->indexPasswd);
             if (!result) {
                 return false;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -38,10 +38,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_util.h"
 
@@ -108,7 +108,7 @@ static bool nv_read(tpm_nvread_ctx *ctx) {
         session_data.sessionHandle = ctx->auth_session_handle;
     }
 
-    bool result = password_tpm2_util_to_auth(&ctx->handle_passwd, ctx->is_hex_password,
+    bool result = tpm2_password_util_fromhex(&ctx->handle_passwd, ctx->is_hex_password,
             "handle password", &session_data.hmac);
     if (!result) {
         return false;
@@ -228,7 +228,7 @@ static bool init(int argc, char *argv[], tpm_nvread_ctx *ctx) {
             }
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->handle_passwd);
             if (!result) {
                 return false;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -39,10 +39,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_nvreadlock_ctx tpm_nvreadlock_ctx;
@@ -87,7 +87,7 @@ static bool nv_readlock(tpm_nvreadlock_ctx *ctx) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->handle_passwd, ctx->is_hex_passwd,
+    bool result = tpm2_password_util_fromhex(&ctx->handle_passwd, ctx->is_hex_passwd,
             "handle password", &session_data.hmac);
     if (!result) {
         return false;
@@ -155,7 +155,7 @@ static bool init(int argc, char *argv[], tpm_nvreadlock_ctx *ctx) {
             }
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->handle_passwd);
             if (!result) {
                 return false;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -37,10 +37,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_nvrelease_ctx tpm_nvrelease_ctx;
@@ -74,7 +74,7 @@ static bool nv_space_release(tpm_nvrelease_ctx *ctx) {
     sessions_data.cmdAuths = &session_data_array[0];
     sessions_data.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->handle_passwd,
+    bool result = tpm2_password_util_fromhex(&ctx->handle_passwd,
             ctx->is_hex_password, "handle password", &session_data.hmac);
     if (!result) {
         return false;
@@ -146,7 +146,7 @@ static bool init(int argc, char* argv[], tpm_nvrelease_ctx *ctx) {
              ctx->is_auth_session = true;
              break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->handle_passwd);
             if (!result) {
                 return false;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -39,7 +39,7 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
@@ -52,33 +52,19 @@ struct tpm_nvwrite_ctx {
     UINT32 auth_handle;
     UINT16 data_size;
     UINT8 nv_buffer[MAX_NV_INDEX_SIZE];
-    TPM2B_AUTH handle_passwd;
-    bool hex_passwd;
+    TPMS_AUTH_COMMAND session_data;
     char *input_file;
     TSS2_SYS_CONTEXT *sapi_context;
-    bool is_auth_session;
-    TPMI_SH_AUTH_SESSION auth_session_handle;
 };
 
 static int nv_write(tpm_nvwrite_ctx *ctx) {
-
-    TPMS_AUTH_COMMAND session_data = {
-        .sessionHandle = TPM_RS_PW,
-        .nonce = TPM2B_EMPTY_INIT,
-        .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
-    };
-
-    if (ctx->is_auth_session) {
-        session_data.sessionHandle = ctx->auth_session_handle;
-    }
 
     TPMS_AUTH_RESPONSE session_data_out;
     TSS2_SYS_CMD_AUTHS sessions_data;
     TSS2_SYS_RSP_AUTHS sessions_data_out;
     TPM2B_MAX_NV_BUFFER nv_write_data;
 
-    TPMS_AUTH_COMMAND *session_data_array[1] = { &session_data };
+    TPMS_AUTH_COMMAND *session_data_array[1] = { &ctx->session_data };
     TPMS_AUTH_RESPONSE *session_data_out_array[1] = { &session_data_out };
 
     sessions_data_out.rspAuths = &session_data_out_array[0];
@@ -86,12 +72,6 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
 
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
-
-    bool result = tpm2_password_util_fromhex(&ctx->handle_passwd, ctx->hex_passwd,
-            "handle password", &session_data.hmac);
-    if (!result) {
-        return false;
-    }
 
     UINT16 offset = 0;
     while (ctx->data_size > 0) {
@@ -136,14 +116,13 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
         { "authHandle"  , required_argument, NULL, 'a' },
         { "file"        , required_argument, NULL, 'f' },
         { "handlePasswd", required_argument, NULL, 'P' },
-        { "passwdInHex" , no_argument,       NULL, 'X' },
         { "input-session-handle",1,          NULL, 'S' },
         { NULL          , no_argument,       NULL,  0  },
     };
 
     int opt;
     bool result;
-    while ((opt = getopt_long(argc, argv, "x:a:f:P:S:X", long_options, NULL))
+    while ((opt = getopt_long(argc, argv, "x:a:f:P:S:", long_options, NULL))
             != -1) {
         switch (opt) {
         case 'x':
@@ -176,22 +155,18 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
             ctx->input_file = optarg;
             break;
         case 'P':
-            result = tpm2_password_util_copy_password(optarg, "handle password",
-                    &ctx->handle_passwd);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
             if (!result) {
+                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
                 return false;
             }
             break;
-        case 'X':
-            ctx->hex_passwd = true;
-            break;
         case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->auth_session_handle)) {
+             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
                  LOG_ERR("Could not convert session handle to number, got: \"%s\"",
                          optarg);
                  return false;
              }
-             ctx->is_auth_session = true;
              break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
@@ -225,8 +200,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
         .nv_index = 0,
         .auth_handle = TPM_RH_PLATFORM,
         .data_size = 0,
-        .handle_passwd = TPM2B_EMPTY_INIT,
-        .hex_passwd = false,
+        .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
         .sapi_context = sapi_context
     };
 

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -39,11 +39,11 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_nvwrite_ctx tpm_nvwrite_ctx;
@@ -87,7 +87,7 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->handle_passwd, ctx->hex_passwd,
+    bool result = tpm2_password_util_fromhex(&ctx->handle_passwd, ctx->hex_passwd,
             "handle password", &session_data.hmac);
     if (!result) {
         return false;
@@ -176,7 +176,7 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
             ctx->input_file = optarg;
             break;
         case 'P':
-            result = password_tpm2_util_copy_password(optarg, "handle password",
+            result = tpm2_password_util_copy_password(optarg, "handle password",
                     &ctx->handle_passwd);
             if (!result) {
                 return false;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -42,8 +42,8 @@
 #include <sapi/tpm20.h>
 #include <tcti/tcti_socket.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "tpm2_util.h"
-#include "password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -363,7 +363,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
             break;
 
         case 'P':
-            if(!password_tpm2_util_copy_password(optarg, "parent key", &sessionData.hmac))
+            if(!tpm2_password_util_copy_password(optarg, "parent key", &sessionData.hmac))
             {
                 showArgError(optarg, argv[0]);
                 return 1;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_readpub_ctx tpm_readpub_ctx;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -38,7 +38,6 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_rsadecrypt_ctx tpm_rsadecrypt_ctx;
@@ -136,7 +136,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = password_tpm2_util_copy_password(optarg, "key",
+            bool result = tpm2_password_util_copy_password(optarg, "key",
                     &ctx->session_data.hmac);
             if (!result) {
                 return false;
@@ -201,7 +201,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         }
     }
 
-   return password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd,
+   return tpm2_password_util_fromhex(&ctx->session_data.hmac, is_hex_passwd,
             "key", &ctx->session_data.hmac);
 }
 

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -38,7 +38,7 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -90,14 +90,13 @@ static bool rsa_decrypt_and_save(tpm_rsadecrypt_ctx *ctx) {
 
 static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
 
-    const char *optstring = "k:P:I:o:c:S:X";
+    const char *optstring = "k:P:I:o:c:S:";
     static struct option long_options[] = {
       { "keyHandle",   required_argument, NULL, 'k'},
       { "pwdk",        required_argument, NULL, 'P'},
       { "inFile",      required_argument, NULL, 'I'},
       { "outFile",     required_argument, NULL, 'o'},
       { "keyContext",  required_argument, NULL, 'c'},
-      { "passwdInHex", no_argument,       NULL, 'X'},
       { "input-session-handle",1,         NULL, 'S' },
       { NULL,          no_argument,       NULL, '\0'}
     };
@@ -120,7 +119,6 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
     }
 
     int opt;
-    bool is_hex_passwd = false;
     char *context_key_file = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL))
             != -1) {
@@ -136,9 +134,9 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = tpm2_password_util_copy_password(optarg, "key",
-                    &ctx->session_data.hmac);
+            bool result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
             if (!result) {
+                LOG_ERR("Invalid key password, got\"%s\"", optarg);
                 return false;
             }
             flags.P = 1;
@@ -166,9 +164,6 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         case 'c':
             context_key_file = optarg;
             flags.c = 1;
-            break;
-        case 'X':
-            is_hex_passwd = true;
             break;
         case 'S':
              if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
@@ -201,8 +196,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         }
     }
 
-   return tpm2_password_util_fromhex(&ctx->session_data.hmac, is_hex_passwd,
-            "key", &ctx->session_data.hmac);
+   return true;
 }
 
 int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 #include "tpm_hash.h"
 #include "tpm2_alg_util.h"
@@ -223,7 +223,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = password_tpm2_util_copy_password(optarg, "key",
+            bool result = tpm2_password_util_copy_password(optarg, "key",
                     &ctx->sessionData.hmac);
             if (!result) {
                 return false;
@@ -300,7 +300,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
         ctx->validation.hierarchy = TPM_RH_NULL;
     }
 
-    bool result = password_tpm2_util_to_auth(&ctx->sessionData.hmac, hexPasswd,
+    bool result = tpm2_password_util_fromhex(&ctx->sessionData.hmac, hexPasswd,
             "key", &ctx->sessionData.hmac);
     if (!result) {
         return false;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -38,7 +38,7 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -173,7 +173,7 @@ static bool sign_and_save(tpm_sign_ctx *ctx) {
 
 static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
 
-    static const char *optstring = "k:P:g:m:t:s:c:S:X";
+    static const char *optstring = "k:P:g:m:t:s:c:S:";
     static const struct option long_options[] = {
       {"keyHandle",1,NULL,'k'},
       {"pwdk",1,NULL,'P'},
@@ -182,7 +182,6 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
       {"sig",1,NULL,'s'},
       {"ticket",1,NULL,'t'},
       {"keyContext",1,NULL,'c'},
-      {"passwdInHex",0,NULL,'X'},
       {"input-session-handle",1,NULL, 'S' },
       {0,0,0,0}
     };
@@ -207,7 +206,6 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
     } flags = { .all = 0 };
 
     int opt;
-    bool hexPasswd = false;
     char *contextKeyFile = NULL;
     char *inMsgFileName = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL)) != -1) {
@@ -223,9 +221,9 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = tpm2_password_util_copy_password(optarg, "key",
-                    &ctx->sessionData.hmac);
+            bool result = tpm2_password_util_from_optarg(optarg, &ctx->sessionData.hmac);
             if (!result) {
+                LOG_ERR("Invalid key password, got\"%s\"", optarg);
                 return false;
             }
             flags.P = 1;
@@ -268,9 +266,6 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
             contextKeyFile = optarg;
             flags.c = 1;
             break;
-        case 'X':
-            hexPasswd = true;
-            break;
         case 'S':
             if (!tpm2_util_string_to_uint32(optarg, &ctx->sessionData.sessionHandle)) {
                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
@@ -300,17 +295,11 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
         ctx->validation.hierarchy = TPM_RH_NULL;
     }
 
-    bool result = tpm2_password_util_fromhex(&ctx->sessionData.hmac, hexPasswd,
-            "key", &ctx->sessionData.hmac);
-    if (!result) {
-        return false;
-    }
-
     /*
      * load tpm context from a file if -c is provided
      */
     if (flags.c) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
+        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
                 contextKeyFile);
         if (!result) {
             return false;
@@ -321,7 +310,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
      * Process the msg file
      */
     unsigned long file_size;
-    result = files_get_file_size(inMsgFileName, &file_size);
+    bool result = files_get_file_size(inMsgFileName, &file_size);
     if (!result) {
         return false;
     }

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -41,10 +41,10 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "options.h"
 #include "main.h"
+#include "tpm2_password_util.h"
 #include "tpm2_util.h"
 
 typedef struct password password;
@@ -60,7 +60,6 @@ struct takeownership_ctx {
         password endorse;
         password lockout;
     } passwords;
-    bool is_hex_passwords;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -79,10 +78,7 @@ bool clear_hierarchy_auth(takeownership_ctx *ctx) {
     sessionsData.cmdAuths = &sessionDataArray[0];
     sessionsData.cmdAuthsCount = 1;
 
-    bool result = tpm2_password_util_fromhex(&ctx->passwords.lockout.old, ctx->is_hex_passwords, "old lockout", &sessionData.hmac);
-    if (!result) {
-        return false;
-    }
+    memcpy(&sessionData.hmac, &ctx->passwords.lockout.old, sizeof(ctx->passwords.lockout.old));
 
     UINT32 rval = Tss2_Sys_Clear(ctx->sapi_context, TPM_RH_LOCKOUT, &sessionsData, 0);
     if (rval != TPM_RC_SUCCESS) {
@@ -144,15 +140,7 @@ static bool change_hierarchy_auth(takeownership_ctx *ctx) {
                     j == 0 ? sources[i].new_passwd : sources[i].old_passwd;
             TPM2B_AUTH *auth_dest = j == 0 ? &newAuth : &sessionData.hmac;
 
-            char desc[256];
-            snprintf(desc, sizeof(desc), "%s %s",
-                    j == 0 ? "new" : "old", sources[i].desc);
-
-            bool result = tpm2_password_util_fromhex(passwd, ctx->is_hex_passwords, desc,
-                    auth_dest);
-            if (!result) {
-                return false;
-            }
+            memcpy(auth_dest, passwd, sizeof(*passwd));
         }
 
         UINT32 rval = Tss2_Sys_HierarchyChangeAuth(ctx->sapi_context,
@@ -179,7 +167,6 @@ static bool init(int argc, char *argv[], char *envp[], takeownership_ctx *ctx,
             { "oldOwnerPasswd",   required_argument, NULL, 'O' },
             { "oldEndorsePasswd", required_argument, NULL, 'E' },
             { "oldLockPasswd",    required_argument, NULL, 'L' },
-            { "passwdInHex",      no_argument,       NULL, 'X' },
             { "clear",            no_argument,       NULL, 'c' },
             { NULL,               no_argument,       NULL, '\0' },
     };
@@ -198,7 +185,7 @@ static bool init(int argc, char *argv[], char *envp[], takeownership_ctx *ctx,
 
     int opt;
     bool result;
-    while ((opt = getopt_long(argc, argv, "o:e:l:O:E:L:Xc", sOpts, NULL))
+    while ((opt = getopt_long(argc, argv, "o:e:l:O:E:L:c", sOpts, NULL))
             != -1) {
 
         switch (opt) {
@@ -207,49 +194,46 @@ static bool init(int argc, char *argv[], char *envp[], takeownership_ctx *ctx,
             break;
 
         case 'o':
-            result = tpm2_password_util_copy_password(optarg, "new owner password",
-                    &ctx->passwords.owner.new);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.owner.new);
             if (!result) {
+                LOG_ERR("Invalid new owner password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'e':
-            result = tpm2_password_util_copy_password(optarg, "new endorse password",
-                    &ctx->passwords.endorse.new);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.endorse.new);
             if (!result) {
+                LOG_ERR("Invalid new endorse password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'l':
-            result = tpm2_password_util_copy_password(optarg, "new lockout password",
-                    &ctx->passwords.lockout.new);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.lockout.new);
             if (!result) {
+                LOG_ERR("Invalid new lockout password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'O':
-            result = tpm2_password_util_copy_password(optarg, "current owner password",
-                    &ctx->passwords.owner.old);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.owner.old);
             if (!result) {
+                LOG_ERR("Invalid current owner password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'E':
-            result = tpm2_password_util_copy_password(optarg, "current endorse password",
-                    &ctx->passwords.endorse.old);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.endorse.old);
             if (!result) {
+                LOG_ERR("Invalid current endorse password, got\"%s\"", optarg);
                 return false;
             }
             break;
         case 'L':
-            result = tpm2_password_util_copy_password(optarg, "current lockout password",
-                    &ctx->passwords.lockout.old);
+            result = tpm2_password_util_from_optarg(optarg, &ctx->passwords.lockout.old);
             if (!result) {
+                LOG_ERR("Invalid current lockout password, got\"%s\"", optarg);
                 return false;
             }
-            break;
-        case 'X':
-            ctx->is_hex_passwords = true;
             break;
         case '?':
         default:
@@ -268,7 +252,6 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
 
     takeownership_ctx ctx = {
             .sapi_context = sapi_context,
-            .is_hex_passwords = false
     };
 
     bool clear_auth = false;

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -41,10 +41,10 @@
 
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "log.h"
 #include "options.h"
 #include "main.h"
-#include "password_util.h"
 #include "tpm2_util.h"
 
 typedef struct password password;
@@ -79,7 +79,7 @@ bool clear_hierarchy_auth(takeownership_ctx *ctx) {
     sessionsData.cmdAuths = &sessionDataArray[0];
     sessionsData.cmdAuthsCount = 1;
 
-    bool result = password_tpm2_util_to_auth(&ctx->passwords.lockout.old, ctx->is_hex_passwords, "old lockout", &sessionData.hmac);
+    bool result = tpm2_password_util_fromhex(&ctx->passwords.lockout.old, ctx->is_hex_passwords, "old lockout", &sessionData.hmac);
     if (!result) {
         return false;
     }
@@ -148,7 +148,7 @@ static bool change_hierarchy_auth(takeownership_ctx *ctx) {
             snprintf(desc, sizeof(desc), "%s %s",
                     j == 0 ? "new" : "old", sources[i].desc);
 
-            bool result = password_tpm2_util_to_auth(passwd, ctx->is_hex_passwords, desc,
+            bool result = tpm2_password_util_fromhex(passwd, ctx->is_hex_passwords, desc,
                     auth_dest);
             if (!result) {
                 return false;
@@ -207,42 +207,42 @@ static bool init(int argc, char *argv[], char *envp[], takeownership_ctx *ctx,
             break;
 
         case 'o':
-            result = password_tpm2_util_copy_password(optarg, "new owner password",
+            result = tpm2_password_util_copy_password(optarg, "new owner password",
                     &ctx->passwords.owner.new);
             if (!result) {
                 return false;
             }
             break;
         case 'e':
-            result = password_tpm2_util_copy_password(optarg, "new endorse password",
+            result = tpm2_password_util_copy_password(optarg, "new endorse password",
                     &ctx->passwords.endorse.new);
             if (!result) {
                 return false;
             }
             break;
         case 'l':
-            result = password_tpm2_util_copy_password(optarg, "new lockout password",
+            result = tpm2_password_util_copy_password(optarg, "new lockout password",
                     &ctx->passwords.lockout.new);
             if (!result) {
                 return false;
             }
             break;
         case 'O':
-            result = password_tpm2_util_copy_password(optarg, "current owner password",
+            result = tpm2_password_util_copy_password(optarg, "current owner password",
                     &ctx->passwords.owner.old);
             if (!result) {
                 return false;
             }
             break;
         case 'E':
-            result = password_tpm2_util_copy_password(optarg, "current endorse password",
+            result = tpm2_password_util_copy_password(optarg, "current endorse password",
                     &ctx->passwords.endorse.old);
             if (!result) {
                 return false;
             }
             break;
         case 'L':
-            result = password_tpm2_util_copy_password(optarg, "current lockout password",
+            result = tpm2_password_util_copy_password(optarg, "current lockout password",
                     &ctx->passwords.lockout.old);
             if (!result) {
                 return false;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -38,7 +38,7 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_password_util.h"
+#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
@@ -95,7 +95,7 @@ bool unseal_and_save(tpm_unseal_ctx *ctx) {
 
 static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
 
-    static const char *optstring = "H:P:o:c:S:L:F:X";
+    static const char *optstring = "H:P:o:c:S:L:F:";
     static const struct option long_options[] = {
       {"item",1,NULL,'H'},
       {"pwdi",1,NULL,'P'},
@@ -104,7 +104,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
       {"input-session-handle",1,NULL,'S'},
       {"set-list", 1, NULL, 'L' },
       {"pcr-input-file", 1, NULL, 'F' },
-      {"passwdInHex",0,NULL,'X'},
       {0,0,0,0}
     };
 
@@ -125,7 +124,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
     } flags = { .all = 0 };
 
     int opt;
-    bool hexPasswd = false;
     char *contextItemFile = NULL;
     char *raw_pcrs_file = NULL;
     TPML_PCR_SELECTION pcr_selections;
@@ -142,9 +140,9 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = tpm2_password_util_copy_password(optarg, "key",
-                    &ctx->sessionData.hmac);
+            bool result = tpm2_password_util_from_optarg(optarg, &ctx->sessionData.hmac);
             if (!result) {
+                LOG_ERR("Invalid item handle password, got\"%s\"", optarg);
                 return false;
             }
             flags.P = 1;
@@ -183,9 +181,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
             raw_pcrs_file = optarg;
             flags.F = 1;
             break;
-        case 'X':
-            hexPasswd = true;
-            break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
             return false;
@@ -201,14 +196,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
     if (!(flags.H || flags.c)) {
         LOG_ERR("Expected options H or c");
         return false;
-    }
-
-    if (flags.P) {
-        bool result = tpm2_password_util_fromhex(&ctx->sessionData.hmac, hexPasswd,
-                "key", &ctx->sessionData.hmac);
-        if (!result) {
-            return false;
-        }
     }
 
     if (flags.c) {

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
+#include "../lib/tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
-#include "password_util.h"
 #include "pcr.h"
 #include "tpm2_policy.h"
 #include "tpm2_util.h"
@@ -142,7 +142,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         }
             break;
         case 'P': {
-            bool result = password_tpm2_util_copy_password(optarg, "key",
+            bool result = tpm2_password_util_copy_password(optarg, "key",
                     &ctx->sessionData.hmac);
             if (!result) {
                 return false;
@@ -204,7 +204,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
     }
 
     if (flags.P) {
-        bool result = password_tpm2_util_to_auth(&ctx->sessionData.hmac, hexPasswd,
+        bool result = tpm2_password_util_fromhex(&ctx->sessionData.hmac, hexPasswd,
                 "key", &ctx->sessionData.hmac);
         if (!result) {
             return false;


### PR DESCRIPTION
This PR drops the -X aka hex password option and allows the specification of formatting in the password string itself. For commands that take multiple passwords, this allows to mix and match hex and string passwords. Before it was just one or the other.

This also gets rid of the crufty conversion/copy routines in password utils and adds unit tests.

This brings issue #321 to a close.

Fixes: #321 
