### PR TITLE
lib: Rename file_load_tpm_context_from_file() to follow coding standard

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -191,7 +191,7 @@ out:
     return result;
 }
 
-bool file_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
+bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context,
         TPM_HANDLE *handle, const char *path) {
 
     TPM_RC rval;

--- a/lib/files.h
+++ b/lib/files.h
@@ -78,7 +78,7 @@ bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE h
  * @return
  *  True on Success, false on error.
  */
-bool file_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE *handle, const char *path);
+bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE *handle, const char *path);
 
 /**
  * Checks a file for existence.

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -332,7 +332,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     }
 
     if (ctx.file.context) {
-        bool res = file_load_tpm_context_from_file(sapi_context, &ctx.handle.activate,
+        bool res = files_load_tpm_context_from_file(sapi_context, &ctx.handle.activate,
                 ctx.file.context);
         if (!res) {
             return 1;
@@ -340,7 +340,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     }
 
     if (ctx.file.key_context) {
-        bool res = file_load_tpm_context_from_file(sapi_context, &ctx.handle.key,
+        bool res = files_load_tpm_context_from_file(sapi_context, &ctx.handle.key,
                 ctx.file.key_context) != true;
         if (!res) {
             return 1;

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -331,7 +331,7 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
 
     /* Load input files */
     if (flags.C) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.obj,
+        result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.obj,
                 context_file);
         if (!result) {
             return false;
@@ -339,7 +339,7 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
     }
 
     if (flags.c) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.key,
+        result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.key,
                 context_key_file);
         if (!result) {
             return false;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -416,7 +416,7 @@ execute_tool (int              argc,
     else if(flagCnt == 3 && (H_flag == 1 || c_flag == 1) && g_flag == 1 && G_flag == 1)
     {
         if(c_flag)
-            returnVal = file_load_tpm_context_from_file(sysContext, &parentHandle, contextParentFilePath) != true;
+            returnVal = files_load_tpm_context_from_file(sysContext, &parentHandle, contextParentFilePath) != true;
         if(returnVal == 0)
             returnVal = create(parentHandle, &inPublic, &inSensitive, type, nameAlg, opuFilePath, oprFilePath, o_flag, O_flag, I_flag, A_flag, objectAttributes, is_policy_enforced);
 

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -214,7 +214,7 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
     }
 
     if (flags.c) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle, contextKeyFile);
+        result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle, contextKeyFile);
         if (!result) {
             return result;
         }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -191,7 +191,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
     }
 
     if (flags.c) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.object,
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->handle.object,
                 contextFile);
         if (!result) {
             return false;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -218,7 +218,7 @@ static bool init(int argc, char *argv[], tpm_hmac_ctx *ctx) {
     }
 
     if (flags.c) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle,
+        result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle,
                 contextKeyFile);
         if (!result) {
             LOG_ERR("Loading tpm context from file \"%s\" failed.",

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -235,7 +235,7 @@ execute_tool (int              argc,
     if(flagCnt == 4 && (H_flag == 1 || c_flag == 1) && u_flag == 1 && r_flag == 1 && n_flag == 1)
     {
         if(c_flag) {
-            returnVal = file_load_tpm_context_from_file (sapi_context,
+            returnVal = files_load_tpm_context_from_file (sapi_context,
                                                 &parentHandle,
                                                 contextParentFilePath) != true;
             if (returnVal) {

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -424,7 +424,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
     {
 
         if(c_flag) {
-            returnVal = file_load_tpm_context_from_file(sapi_context, &akHandle, contextFilePath);
+            returnVal = files_load_tpm_context_from_file(sapi_context, &akHandle, contextFilePath);
             if (!returnVal) {
                 return 1;
             }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -150,7 +150,7 @@ static bool init(int argc, char *argv[], tpm_readpub_ctx * ctx) {
     }
 
     if (flags.c) {
-        result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->objectHandle,
+        result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->objectHandle,
                 context_file);
         if (!result) {
             return false;

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -190,7 +190,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
     }
 
     if (flags.c) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle, context_key_file);
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle, context_key_file);
         if (!result) {
             return false;
         }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -165,7 +165,7 @@ static bool init(int argc, char *argv[], tpm_rsaencrypt_ctx *ctx) {
     }
 
     if (flags.c) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle,
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle,
                 context_key_file);
         if (!result) {
             return false;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -299,7 +299,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
      * load tpm context from a file if -c is provided
      */
     if (flags.c) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
                 contextKeyFile);
         if (!result) {
             return false;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -199,7 +199,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
     }
 
     if (flags.c) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->itemHandle,
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->itemHandle,
                 contextItemFile);
         if (!result) {
             return false;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -179,7 +179,7 @@ static bool init(tpm2_verifysig_ctx *ctx) {
     }
 
     if (ctx->flags.key_context) {
-        bool result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
+        bool result = files_load_tpm_context_from_file(ctx->sapi_context, &ctx->keyHandle,
                 ctx->context_key_file_path);
         if (!result) {
             goto err;


### PR DESCRIPTION
The coding standard document says that a function that is exported should
be prefixed with the source file (or object module) name it was defined.

But file_load_tpm_context_from_file() is using file as prefix instead of
files. This is trivial but since there is a bug filled for this, fix it.

Fixes: #367

Reported-by: 刘群 <qunliu@zyhx-group.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>