### PR TITLE
Improve log messages support

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -226,7 +226,7 @@ get_common_opts (int                    *argc_param,
     char **argv = *argv_param;
 
     int c = 0, option_index = 0;
-    char *arg_str = "-T:d:R:p:hvV";
+    char *arg_str = "-T:d:R:p:hvVQ";
     struct option long_options [] = {
         {
             .name    = "tcti",
@@ -270,6 +270,12 @@ get_common_opts (int                    *argc_param,
             .has_arg = no_argument,
             .flag    = NULL,
             .val     = 'V',
+        },
+        {
+            .name    = "quiet",
+            .has_arg = no_argument,
+            .flag    = NULL,
+            .val     = 'Q',
         },
         {
             .name    = "version",
@@ -350,6 +356,9 @@ get_common_opts (int                    *argc_param,
             break;
         case 'V':
             common_opts->verbose = true;
+            break;
+        case 'Q':
+            common_opts->quiet = true;
             break;
         case 'v':
             common_opts->version = true;

--- a/lib/options.c
+++ b/lib/options.c
@@ -196,7 +196,7 @@ append_arg_to_vector (int*  argc,
     if (new_argv != NULL) {
         new_argv[*argc - 1] = arg_string;
     } else {
-        LOG_ERR("Failed to realloc new_argv to append string %s: %s\n",
+        LOG_ERR("Failed to realloc new_argv to append string %s: %s",
                 arg_string,
                 strerror (errno));
     }

--- a/lib/options.h
+++ b/lib/options.h
@@ -76,6 +76,7 @@
     .socket_port    = TCTI_SOCKET_DEFAULT_PORT, \
     .help           = false, \
     .verbose        = false, \
+    .quiet          = false, \
     .version        = false, \
 }
 
@@ -100,6 +101,7 @@ typedef struct {
     uint16_t  socket_port;
     int       help;
     int       verbose;
+    int       quiet;
     int       version;
 } common_opts_t;
 

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -56,7 +56,7 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION pcr_selections,
         unsigned long filesize = 0;
         bool result = files_get_file_size(raw_pcrs_file, &filesize);
         if (!result) {
-            LOG_ERR("Could not retrieve raw_pcrs_file size\n");
+            LOG_ERR("Could not retrieve raw_pcrs_file size");
             return false;
         }
         if (filesize != expected_pcr_input_file_size) {
@@ -154,7 +154,7 @@ static TPM_RC start_policy_session (TSS2_SYS_CONTEXT *sapi_context,
                                                      &symmetric,
                                                      policy_digest_hash_alg);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed tpm session start auth with params\n");
+        LOG_ERR("Failed tpm session start auth with params");
     }
     return rval;
 }
@@ -176,14 +176,14 @@ TPM_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
                                        policy_session_type,
                                        policy_digest_hash_alg);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Error starting the policy session.\n");
+        LOG_ERR("Error starting the policy session.");
         return rval;
     }
     // Issue policy command.
     rval = (*build_policy_function)(sapi_context, *policy_session,
                                     pcr_selections, raw_pcrs_file);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed parse_policy_type_and_send_command\n");
+        LOG_ERR("Failed parse_policy_type_and_send_command");
         return rval;
     }
     // Get Policy Hash
@@ -191,7 +191,7 @@ TPM_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
                                     (*policy_session)->sessionHandle,
                                     0, policy_digest, 0);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed Policy Get Digest\n");
+        LOG_ERR("Failed Policy Get Digest");
         return rval;
     }
 
@@ -200,7 +200,7 @@ TPM_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
         rval = Tss2_Sys_FlushContext(sapi_context,
                                      (*policy_session)->sessionHandle);
         if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("Failed Flush Context\n");
+            LOG_ERR("Failed Flush Context");
             return rval;
         }
 

--- a/man/common-options.troff
+++ b/man/common-options.troff
@@ -11,4 +11,9 @@ Display version information for this tool.
 .TP
 \fB\-V,\ \-\-verbose\fR
 Increase the information that the tool prints to the console during its
-execution.
+execution. When using this option the file and line number are printed.
+.TP
+.TP
+\fB\-Q,\ \-\-quiet\fR
+Decrease the information that the tool prints to the console during its
+execution. With this option the tools output messages are not printed.

--- a/tools/main.c
+++ b/tools/main.c
@@ -35,6 +35,8 @@
 #include "main.h"
 #include "options.h"
 
+bool output_enabled = true;
+
 /*
  * This program is a template for TPM2 tools that use the SAPI. It does
  * nothing more than parsing command line options that allow the caller to
@@ -71,6 +73,10 @@ main (int   argc,
     }
     if (opts.verbose)
         log_set_level(log_level_verbose);
+
+    if (opts.quiet) {
+        disable_output();
+    }
 
     sapi_context = sapi_init_from_options (&opts);
     if (sapi_context == NULL)

--- a/tools/main.c
+++ b/tools/main.c
@@ -59,7 +59,7 @@ main (int   argc,
     switch (sanity_check_common (&opts)) {
     case 1:
         execute_man (argv[0], envp);
-        LOG_ERR ("failed to load manpage, check your environment / PATH\n");
+        LOG_ERR ("failed to load manpage, check your environment / PATH");
         exit (1);
     case 2:
         exit (1);

--- a/tools/main.h
+++ b/tools/main.h
@@ -32,7 +32,10 @@
 #define MAIN_H
 
 #include <sapi/tpm20.h>
+#include <stdbool.h>
 #include "options.h"
+
+extern bool output_enabled;
 
 int
 execute_tool (int              argc,
@@ -40,5 +43,26 @@ execute_tool (int              argc,
               char             *envp[],
               common_opts_t    *opts,
               TSS2_SYS_CONTEXT *sapi_context);
+
+/*
+ * Prints output messages if not disabled. Output messages are what tools prints
+ * to the standard output during normal execution.
+ */
+#define TOOL_OUTPUT(fmt, ...)                   \
+    do {                                        \
+        if (output_enabled) {                   \
+            printf(fmt, ##__VA_ARGS__);         \
+        }                                       \
+    } while (0)
+
+static inline void enable_output(void)
+{
+    output_enabled = true;
+}
+
+static inline void disable_output(void)
+{
+    output_enabled = false;
+}
 
 #endif /* MAIN_H */

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -290,13 +290,13 @@ static bool init(int argc, char *argv[], tpm_activatecred_ctx *ctx) {
             o_flag = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     };
@@ -327,7 +327,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
 
     bool result = init(argc, argv, &ctx);
     if (!result) {
-        LOG_ERR("Initialization failed\n");
+        LOG_ERR("Initialization failed");
         return 1;
     }
 

--- a/tools/tpm2_akparse.c
+++ b/tools/tpm2_akparse.c
@@ -201,13 +201,13 @@ static bool init(int argc, char *argv[], tpm_akparse_ctx *ctx) {
             ctx->ak_key_file_path = optarg;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -156,7 +156,7 @@ static bool certify_and_save_data(tpm_certify_ctx *ctx) {
     TPMT_SIG_SCHEME scheme;
     bool result = set_scheme(ctx->sapi_context, ctx->handle.key, ctx->halg, &scheme);
     if (!result) {
-        LOG_ERR("No suitable signing scheme!\n");
+        LOG_ERR("No suitable signing scheme!");
         return false;
     }
 
@@ -310,15 +310,15 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             flags.C = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             result = false;
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             result = false;
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             result = false;
             return false;
         }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -70,7 +70,7 @@ int setAlg(TPMI_ALG_PUBLIC type,TPMI_ALG_HASH nameAlg,TPM2B_PUBLIC *inPublic, in
         inPublic->t.publicArea.nameAlg = nameAlg;
         break;
     default:
-        printf("nameAlg algrithm: 0x%0x not support !\n", nameAlg);
+        LOG_ERR("nameAlg algrithm: 0x%0x not support !", nameAlg);
         return -1;
     }
 
@@ -132,7 +132,7 @@ int setAlg(TPMI_ALG_PUBLIC type,TPMI_ALG_HASH nameAlg,TPM2B_PUBLIC *inPublic, in
         break;
 
     default:
-        printf("type algrithm: 0x%0x not support !\n",type);
+        LOG_ERR("type algrithm: 0x%0x not support !",type);
         return -2;
     }
     return 0;
@@ -174,7 +174,7 @@ int create(TPMI_DH_OBJECT parentHandle, TPM2B_PUBLIC *inPublic, TPM2B_SENSITIVE_
 
     if(A_flag == 1)
         inPublic->t.publicArea.objectAttributes.val = objectAttributes;
-    printf("ObjectAttribute: 0x%08X\n",inPublic->t.publicArea.objectAttributes.val);
+    TOOL_OUTPUT("ObjectAttribute: 0x%08X\n",inPublic->t.publicArea.objectAttributes.val);
 
     creationPCR.count = 0;
 
@@ -183,10 +183,10 @@ int create(TPMI_DH_OBJECT parentHandle, TPM2B_PUBLIC *inPublic, TPM2B_SENSITIVE_
             &creationTicket, &sessionsDataOut);
     if(rval != TPM_RC_SUCCESS)
     {
-        printf("\nCreate Object Failed ! ErrorCode: 0x%0x\n\n",rval);
+        LOG_ERR("\nCreate Object Failed ! ErrorCode: 0x%0x\n",rval);
         return -2;
     }
-    printf("\nCreate Object Succeed !\n");
+    TOOL_OUTPUT("\nCreate Object Succeed !\n");
 
     /*
      * TODO These public and private serializations are not safe since its outputting size as well.
@@ -302,7 +302,7 @@ execute_tool (int              argc,
                 showArgError(optarg, argv[0]);
                 return 1;
             }
-            printf("nameAlg = 0x%4.4x\n", nameAlg);
+            TOOL_OUTPUT("nameAlg = 0x%4.4x\n", nameAlg);
             g_flag = 1;
             break;
         case 'G':
@@ -312,7 +312,7 @@ execute_tool (int              argc,
                 showArgError(optarg, argv[0]);
                 return 1;
             }
-            printf("type = 0x%4.4x\n", type);
+            TOOL_OUTPUT("type = 0x%4.4x\n", type);
             G_flag = 1;
             break;
         case 'A':
@@ -335,7 +335,7 @@ execute_tool (int              argc,
                 return 1;
             }
             I_flag = 1;
-            printf("inSensitive.t.sensitive.data.t.size = %d\n",inSensitive.t.sensitive.data.t.size);
+            TOOL_OUTPUT("inSensitive.t.sensitive.data.t.size = %d\n",inSensitive.t.sensitive.data.t.size);
             break;
         case 'L':
             inPublic.t.publicArea.authPolicy.t.size = sizeof(inPublic.t.publicArea.authPolicy) - 2;
@@ -377,7 +377,7 @@ execute_tool (int              argc,
             {
                 return 1;
             }
-            printf("contextParentFile = %s\n", contextParentFilePath);
+            TOOL_OUTPUT("contextParentFile = %s\n", contextParentFilePath);
             c_flag = 1;
             break;
         case ':':

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -381,13 +381,13 @@ execute_tool (int              argc,
             c_flag = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return 1;
 	case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return 1;
 	default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return 1;
         }
     };
@@ -398,7 +398,7 @@ execute_tool (int              argc,
     if(I_flag == 0) {
         inSensitive.t.sensitive.data.t.size = 0;
     } else if (type != TPM_ALG_KEYEDHASH) {
-        LOG_ERR("Only TPM_ALG_KEYEDHASH algorithm is allowed when sealing data\n");
+        LOG_ERR("Only TPM_ALG_KEYEDHASH algorithm is allowed when sealing data");
         return 1;
     }
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -88,7 +88,7 @@ struct create_policy_ctx {
 static TPM_RC parse_policy_type_specific_command (create_policy_ctx *pctx) {
     TPM_RC rval = TPM_RC_SUCCESS;
     if (!pctx->common_policy_options.policy_type.is_policy_type_selected){
-        LOG_ERR("No Policy type chosen.\n");
+        LOG_ERR("No Policy type chosen.");
         return rval;
     }
 
@@ -175,7 +175,7 @@ static bool init(int argc, char *argv[], create_policy_ctx *pctx) {
             if(pctx->common_policy_options.policy_digest_hash_alg
                     == TPM_ALG_ERROR) {
                 showArgError(optarg, argv[0]);
-                LOG_ERR("Invalid choice for policy digest hash algorithm\n");
+                LOG_ERR("Invalid choice for policy digest hash algorithm");
                 return false;
             }
             break;
@@ -190,25 +190,25 @@ static bool init(int argc, char *argv[], create_policy_ctx *pctx) {
         case 'P':
             pctx->common_policy_options.policy_type.PolicyPCR = true;
             pctx->common_policy_options.policy_type.is_policy_type_selected= true;
-            LOG_INFO("Policy type chosen is policyPCR.\n");
+            LOG_INFO("Policy type chosen is policyPCR.");
             break;
         case 'a':
             pctx->common_policy_options.policy_session_type = TPM_SE_POLICY;
             pctx->common_policy_options.extend_policy_session = true;
-            LOG_INFO("Policy session setup for auth.\n");
+            LOG_INFO("Policy session setup for auth.");
             break;
         case 'e':
             pctx->common_policy_options.extend_policy_session = true;
-            LOG_INFO("Policy session setup to extend after operation.\n");
+            LOG_INFO("Policy session setup to extend after operation.");
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -300,13 +300,13 @@ execute_tool (int               argc,
             }
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return 1;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return 1;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return 1;
         }
     };

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -72,7 +72,7 @@ int setAlg(TPMI_ALG_PUBLIC type,TPMI_ALG_HASH nameAlg,TPM2B_PUBLIC *inPublic, bo
         inPublic->t.publicArea.nameAlg = nameAlg;
         break;
     default:
-        printf("nameAlg algrithm: 0x%0x not support !\n", nameAlg);
+        LOG_ERR("nameAlg algrithm: 0x%0x not support !", nameAlg);
         return -1;
     }
 
@@ -124,7 +124,7 @@ int setAlg(TPMI_ALG_PUBLIC type,TPMI_ALG_HASH nameAlg,TPM2B_PUBLIC *inPublic, bo
         break;
 
     default:
-        printf("type algrithm: 0x%0x not support !\n",type);
+        LOG_ERR("type algrithm: 0x%0x not support !", type);
         return -2;
     }
     return 0;
@@ -168,10 +168,10 @@ int createPrimary(TSS2_SYS_CONTEXT *sysContext, TPMI_RH_HIERARCHY hierarchy,
     rval = Tss2_Sys_CreatePrimary(sysContext, hierarchy, &sessionsData, inSensitive, inPublic,  &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash, &creationTicket, &name, &sessionsDataOut);
     if(rval != TPM_RC_SUCCESS)
     {
-        printf("\nCreatePrimary Failed ! ErrorCode: 0x%0x\n\n",rval);
+        LOG_ERR("\nCreatePrimary Failed ! ErrorCode: 0x%0x\n", rval);
         return -2;
     }
-    printf("\nCreatePrimary Succeed ! Handle: 0x%8.8x\n\n",handle2048rsa);
+    TOOL_OUTPUT("\nCreatePrimary Succeed ! Handle: 0x%8.8x\n\n", handle2048rsa);
     return 0;
 }
 
@@ -260,7 +260,7 @@ execute_tool (int               argc,
                 showArgError(optarg, argv[0]);
                 return 1;
             }
-            printf("nameAlg = 0x%4.4x\n", nameAlg);
+            TOOL_OUTPUT("nameAlg = 0x%4.4x\n", nameAlg);
             g_flag = 1;
             break;
         case 'G':
@@ -270,7 +270,7 @@ execute_tool (int               argc,
                 showArgError(optarg, argv[0]);
                 return 1;
             }
-            printf("type = 0x%4.4x\n", type);
+            TOOL_OUTPUT("type = 0x%4.4x\n", type);
             G_flag = 1;
             break;
         case 'C':
@@ -279,7 +279,7 @@ execute_tool (int               argc,
             {
                 return 1;
             }
-            printf("contextFile = %s\n", contextFile);
+            TOOL_OUTPUT("contextFile = %s\n", contextFile);
             C_flag = 1;
             break;
         case 'L':

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -77,24 +77,24 @@ bool dictionary_lockout_reset_and_parameter_setup(dictionarylockout_ctx *ctx) {
      */
     if (ctx->clear_lockout) {
 
-        LOG_INFO("Resetting dictionary lockout state.\n");
+        LOG_INFO("Resetting dictionary lockout state.");
         UINT32 rval = Tss2_Sys_DictionaryAttackLockReset(ctx->sapi_context,
                 TPM_RH_LOCKOUT, &sessionsData, &sessionsDataOut);
         if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("0x%X Error clearing dictionary lockout.\n", rval);
+            LOG_ERR("0x%X Error clearing dictionary lockout.", rval);
             return false;
         }
     }
 
     if (ctx->setup_parameters) {
-        LOG_INFO("Setting up Dictionary Lockout parameters.\n");
+        LOG_INFO("Setting up Dictionary Lockout parameters.");
         UINT32 rval = Tss2_Sys_DictionaryAttackParameters(ctx->sapi_context,
                 TPM_RH_LOCKOUT, &sessionsData, ctx->max_tries,
                 ctx->recovery_time, ctx->lockout_recovery_time,
                 &sessionsDataOut);
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR(
-                    "0x%X Failed setting up dictionary_attack_lockout_reset params\n",
+                    "0x%X Failed setting up dictionary_attack_lockout_reset params",
                     rval);
             return false;
         }
@@ -174,19 +174,19 @@ static bool init(int argc, char *argv[], dictionarylockout_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }
 
     if (!ctx->clear_lockout && !ctx->setup_parameters) {
-        LOG_ERR( "Invalid operational input: Neither Setup nor Clear lockout requested.\n");
+        LOG_ERR( "Invalid operational input: Neither Setup nor Clear lockout requested.");
         return false;
     }
 

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -89,7 +89,7 @@ static bool encryptDecrypt(tpm_encrypt_decrypt_ctx *ctx) {
             &sessions_data, ctx->is_decrypt, TPM_ALG_NULL, &iv_in, &ctx->data, &out_data,
             &iv_out, &sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("EncryptDecrypt failed, error code: 0x%x\n", rval);
+        LOG_ERR("EncryptDecrypt failed, error code: 0x%x", rval);
         return false;
     }
 
@@ -197,13 +197,13 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return result;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return result;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return result;
         }
     }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -78,7 +78,7 @@ static int evict_control(tpm_evictcontrol_ctx *ctx) {
 
     TPM_RC rval = Tss2_Sys_EvictControl(ctx->sapi_context, ctx->auth, ctx->handle.object, &sessions_data, ctx->handle.persist,&sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("EvictControl failed, error code: 0x%x\n", rval);
+        LOG_ERR("EvictControl failed, error code: 0x%x", rval);
         return false;
     }
     return true;
@@ -174,13 +174,13 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -127,7 +127,7 @@ int setKeyAlgorithm(UINT16 algorithm, TPM2B_PUBLIC *inPublic)
         inPublic->t.publicArea.unique.sym.t.size = 0;
         break;
     default:
-        LOG_ERR("\nThe algorithm type input(%4.4x) is not supported!\n", algorithm);
+        LOG_ERR("\nThe algorithm type input(%4.4x) is not supported!", algorithm);
         return -1;
     }
 
@@ -189,7 +189,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
 
                 if (tpm2_util_hex_to_byte_structure(endorsePasswd, &sessionData.hmac.t.size,
                                       sessionData.hmac.t.buffer) != 0) {
-                        LOG_ERR("Failed to convert Hex format password for endorsePasswd.\n");
+                        LOG_ERR("Failed to convert Hex format password for endorsePasswd.");
                         return -1;
                 }
         }
@@ -205,7 +205,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
              inSensitive.t.sensitive.userAuth.t.size = sizeof(inSensitive.t.sensitive.userAuth) - 2;
              if (tpm2_util_hex_to_byte_structure(ekPasswd, &inSensitive.t.sensitive.userAuth.t.size,
                                    inSensitive.t.sensitive.userAuth.t.buffer) != 0) {
-                  LOG_ERR("Failed to convert Hex format password for ekPasswd.\n");
+                  LOG_ERR("Failed to convert Hex format password for ekPasswd.");
                   return -1;
             }
         }
@@ -225,10 +225,10 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
                                   &creationData, &creationHash, &creationTicket,
                                   &name, &sessionsDataOut);
     if (rval != TPM_RC_SUCCESS ) {
-          LOG_ERR("\nTPM2_CreatePrimary Error. TPM Error:0x%x\n", rval);
+          LOG_ERR("\nTPM2_CreatePrimary Error. TPM Error:0x%x", rval);
           return -2;
     }
-    LOG_INFO("\nEK create succ.. Handle: 0x%8.8x\n", handle2048ek);
+    LOG_INFO("\nEK create succ.. Handle: 0x%8.8x", handle2048ek);
 
     if (!nonPersistentRead) {
          /*
@@ -244,7 +244,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
                 sessionData.hmac.t.size = sizeof(sessionData.hmac) - 2;
                 if (tpm2_util_hex_to_byte_structure(ownerPasswd, &sessionData.hmac.t.size,
                                    sessionData.hmac.t.buffer) != 0) {
-                 LOG_ERR("Failed to convert Hex format password for ownerPasswd.\n");
+                 LOG_ERR("Failed to convert Hex format password for ownerPasswd.");
                  return -1;
                 }
             }
@@ -253,24 +253,24 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
         rval = Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, handle2048ek,
                                      &sessionsData, persistentHandle, &sessionsDataOut);
         if (rval != TPM_RC_SUCCESS ) {
-            LOG_ERR("\nEvictControl:Make EK persistent Error. TPM Error:0x%x\n", rval);
+            LOG_ERR("\nEvictControl:Make EK persistent Error. TPM Error:0x%x", rval);
             return -3;
         }
-        LOG_INFO("EvictControl EK persistent succ.\n");
+        LOG_INFO("EvictControl EK persistent succ.");
     }
 
     rval = Tss2_Sys_FlushContext(sapi_context,
                                  handle2048ek);
     if (rval != TPM_RC_SUCCESS ) {
-        LOG_ERR("\nFlush transient EK failed. TPM Error:0x%x\n", rval);
+        LOG_ERR("\nFlush transient EK failed. TPM Error:0x%x", rval);
         return -4;
     }
 
-    LOG_INFO("Flush transient EK succ.\n");
+    LOG_INFO("Flush transient EK succ.");
 
     /* TODO this serialization is not correct */
     if (!files_save_bytes_to_file(outputFile, (UINT8 *)&outPublic, sizeof(outPublic))) {
-        LOG_ERR("\nFailed to save EK pub key into file(%s)\n", outputFile);
+        LOG_ERR("\nFailed to save EK pub key into file(%s)", outputFile);
         return -5;
     }
 
@@ -284,7 +284,7 @@ unsigned char *HashEKPublicKey(void)
 
     unsigned char EKpubKey[259];
 
-    LOG_INFO("Calculating the SHA256 hash of the Endorsement Public Key\n");
+    LOG_INFO("Calculating the SHA256 hash of the Endorsement Public Key");
 
     fp = fopen(outputFile, "rb");
     if (!fp) {
@@ -294,7 +294,7 @@ unsigned char *HashEKPublicKey(void)
 
     int rc = fseek(fp, 0x66, 0);
     if (rc < 0) {
-        LOG_ERR("Could not perform fseek: %s\n", strerror(errno));
+        LOG_ERR("Could not perform fseek: %s", strerror(errno));
         goto out;
     }
 
@@ -354,7 +354,7 @@ char *Base64Encode(const unsigned char* buffer)
     BIO *bio, *b64;
     BUF_MEM *bufferPtr;
 
-    LOG_INFO("Calculating the Base64Encode of the hash of the Endorsement Public Key:\n");
+    LOG_INFO("Calculating the Base64Encode of the hash of the Endorsement Public Key:");
 
     if (buffer == NULL) {
         LOG_ERR("HashEKPublicKey returned null");
@@ -468,7 +468,7 @@ int RetrieveEndorsementCredentials(char *b64h)
 
     rc = curl_easy_perform(curl);
     if (rc != CURLE_OK) {
-        LOG_ERR("curl_easy_perform() failed: %s\n", curl_easy_strerror(rc));
+        LOG_ERR("curl_easy_perform() failed: %s", curl_easy_strerror(rc));
         goto out_easy_cleanup;
     }
 
@@ -488,7 +488,7 @@ out_memory:
 int TPMinitialProvisioning(void)
 {
     if (EKserverAddr == NULL) {
-        LOG_ERR("TPM Manufacturer Endorsement Credential Server Address cannot be NULL\n");
+        LOG_ERR("TPM Manufacturer Endorsement Credential Server Address cannot be NULL");
         return -99;
     }
 
@@ -498,7 +498,7 @@ int TPMinitialProvisioning(void)
         return -1;
     }
 
-    LOG_INFO("%s\n", b64);
+    LOG_INFO("%s", b64);
 
     int rc = RetrieveEndorsementCredentials(b64);
     free(b64);
@@ -547,14 +547,14 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
               switch ( opt ) {
                 case 'H':
                     if (!tpm2_util_string_to_uint32(optarg, &persistentHandle)) {
-                        LOG_ERR("\nPlease input the handle used to make EK persistent(hex) in correct format.\n");
+                        LOG_ERR("\nPlease input the handle used to make EK persistent(hex) in correct format.");
                         return 1;
                     }
                     break;
 
                 case 'e':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
-                        LOG_ERR("\nPlease input the endorsement password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
+                        LOG_ERR("\nPlease input the endorsement password(optional,no more than %d characters).", (int)sizeof(TPMU_HA) - 1);
                         return 1;
                     }
                     endorsePasswd = optarg;
@@ -562,7 +562,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
 
                 case 'o':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
-                        LOG_ERR("\nPlease input the owner password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
+                        LOG_ERR("\nPlease input the owner password(optional,no more than %d characters).", (int)sizeof(TPMU_HA) - 1);
                         return 1;
                     }
                     ownerPasswd = optarg;
@@ -570,7 +570,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
 
                 case 'P':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
-                        LOG_ERR("\nPlease input the EK password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
+                        LOG_ERR("\nPlease input the EK password(optional,no more than %d characters).", (int)sizeof(TPMU_HA) - 1);
                         return 1;
                     }
                     ekPasswd = optarg;
@@ -579,14 +579,14 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                 case 'g':
                     algorithmType = tpm2_alg_util_from_optarg(optarg);
                     if (algorithmType == TPM_ALG_ERROR) {
-                        LOG_ERR("\nPlease input the algorithm type in correct format.\n");
+                        LOG_ERR("\nPlease input the algorithm type in correct format.");
                         return 1;
                     }
                     break;
 
                 case 'f':
                     if (optarg == NULL ) {
-                        LOG_ERR("\nPlease input the file used to save the pub ek.\n");
+                        LOG_ERR("\nPlease input the file used to save the pub ek.");
                         return 1;
                     }
                     outputFile = optarg;
@@ -601,23 +601,23 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                     break;
                 case 'N':
                     nonPersistentRead = 1;
-                    LOG_INFO("Tss2_Sys_CreatePrimary called with Endorsement Handle without making it persistent\n");
+                    LOG_INFO("Tss2_Sys_CreatePrimary called with Endorsement Handle without making it persistent");
                     break;
                 case 'O':
                     OfflineProv = 1;
-                    LOG_INFO("Setting up for offline provisioning - reading the retrieved EK specified by the file \n");
+                    LOG_INFO("Setting up for offline provisioning - reading the retrieved EK specified by the file ");
                     break;
                 case 'U':
                     SSL_NO_VERIFY = 1;
-                    LOG_WARN("TLS communication with the said TPM manufacturer server setup with SSL_NO_VERIFY!\n");
+                    LOG_WARN("TLS communication with the said TPM manufacturer server setup with SSL_NO_VERIFY!");
                     break;
                 case 'S':
                     if (EKserverAddr) {
-                        LOG_ERR("Multiple specifications of -S\n");
+                        LOG_ERR("Multiple specifications of -S");
                         return 1;
                     }
                     EKserverAddr = optarg;
-                    LOG_INFO("TPM Manufacturer EK provisioning address -- %s\n", EKserverAddr);
+                    LOG_INFO("TPM Manufacturer EK provisioning address -- %s", EKserverAddr);
                     break;
                 case 'i':
                     return_val = tpm2_util_string_to_uint32(optarg, &auth_session_handle);
@@ -629,7 +629,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                     is_session_based_auth = true;
                     break;
                 default:
-                    LOG_ERR("Unknown option\n");
+                    LOG_ERR("Unknown option");
                     return 1;
             }
     }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -357,7 +357,7 @@ static bool create_ak(getpubak_context *ctx) {
     rval = Tss2_Sys_EvictControl(ctx->sapi_context, TPM_RH_OWNER, loaded_sha1_key_handle,
             &sessions_data, ctx->persistent_handle.ak, &sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("\n......TPM2_EvictControl Error. TPM Error:0x%x......\n",
+        LOG_ERR("\n......TPM2_EvictControl Error. TPM Error:0x%x......",
                 rval);
         return false;
     }
@@ -480,13 +480,13 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
             ctx->aknameFile = optarg;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -274,7 +274,7 @@ static bool init(int argc, char *argv[], char *envp[], getpubek_context *ctx) {
         case 'H':
             result = tpm2_util_string_to_uint32(optarg, &ctx->persistent_handle);
             if (!result) {
-                LOG_ERR("Could not convert EK persistent from hex format.\n");
+                LOG_ERR("Could not convert EK persistent from hex format.");
                 return false;
             }
             break;
@@ -324,13 +324,13 @@ static bool init(int argc, char *argv[], char *envp[], getpubek_context *ctx) {
             ctx->is_session_based_auth = true;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
         }
 
     }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -100,13 +100,13 @@ static bool init(int argc, char *argv[], tpm_random_ctx *ctx) {
             ctx->output_file = optarg;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -60,7 +60,7 @@ static bool get_hierarchy_value(const char *hiearchy_code,
 
     size_t len = strlen(hiearchy_code);
     if (len != 1) {
-        LOG_ERR("Hierarchy Values are single characters, got: %s\n",
+        LOG_ERR("Hierarchy Values are single characters, got: %s",
                 hiearchy_code);
         return false;
     }
@@ -79,7 +79,7 @@ static bool get_hierarchy_value(const char *hiearchy_code,
         *hierarchy_value = TPM_RH_NULL;
         break;
     default:
-        LOG_ERR("Unknown hierarchy value: %s\n", hiearchy_code);
+        LOG_ERR("Unknown hierarchy value: %s", hiearchy_code);
         return false;
     }
     return true;
@@ -193,13 +193,13 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
             }
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -198,13 +198,13 @@ static bool init(int argc, char *argv[], tpm_hmac_ctx *ctx) {
             }
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -45,8 +45,6 @@
 #include "options.h"
 #include "tpm2_util.h"
 
-int debugLevel = 0;
-
 int readPublic(TSS2_SYS_CONTEXT *sapi_context,
                TPMI_DH_OBJECT    objectHandle)
 {

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -91,10 +91,10 @@ load (TSS2_SYS_CONTEXT *sapi_context,
                           &sessionsDataOut);
     if(rval != TPM_RC_SUCCESS)
     {
-        printf("\nLoad Object Failed ! ErrorCode: 0x%0x\n\n",rval);
+        LOG_ERR("\nLoad Object Failed ! ErrorCode: 0x%0x\n",rval);
         return -1;
     }
-    printf("\nLoad succ.\nLoadedHandle: 0x%08x\n\n",handle2048rsa);
+    TOOL_OUTPUT("\nLoad succ.\nLoadedHandle: 0x%08x\n\n",handle2048rsa);
 
     /* TODO fix serialization */
     if(!files_save_bytes_to_file(outFileName, (UINT8 *)&nameExt, sizeof(nameExt)))
@@ -159,7 +159,7 @@ execute_tool (int              argc,
             {
                 return 1;
             }
-            printf("\nparentHandle: 0x%x\n\n",parentHandle);
+            TOOL_OUTPUT("\nparentHandle: 0x%x\n\n",parentHandle);
             H_flag = 1;
             break;
         case 'P': {
@@ -200,7 +200,7 @@ execute_tool (int              argc,
             {
                 return 1;
             }
-            printf("contextParentFile = %s\n", contextParentFilePath);
+            TOOL_OUTPUT("contextParentFile = %s\n", contextParentFilePath);
             c_flag = 1;
             break;
         case 'C':
@@ -209,7 +209,7 @@ execute_tool (int              argc,
             {
                 return 1;
             }
-            printf("contextFile = %s\n", contextFile);
+            TOOL_OUTPUT("contextFile = %s\n", contextFile);
             C_flag = 1;
             break;
         case 'S':

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -220,13 +220,13 @@ execute_tool (int              argc,
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return 1;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return 1;
 	default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return 1;
         }
     };

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -168,13 +168,13 @@ static bool init(int argc, char *argv[], tpm_loadexternal_ctx *ctx) {
             ctx->save_to_context_file = true;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -200,13 +200,13 @@ static bool init(int argc, char *argv[], tpm_makecred_ctx *ctx) {
             flags.o = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -207,13 +207,13 @@ static bool init(int argc, char* argv[], tpm_nvdefine_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -242,13 +242,13 @@ static bool init(int argc, char *argv[], tpm_nvread_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -149,13 +149,13 @@ static bool init(int argc, char *argv[], tpm_nvreadlock_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -68,7 +68,7 @@ static bool nv_space_release(tpm_nvrelease_ctx *ctx) {
         return false;
     }
 
-    LOG_INFO("Success to release NV area at index 0x%x (%d).\n", ctx->nv_index,
+    LOG_INFO("Success to release NV area at index 0x%x (%d).", ctx->nv_index,
             ctx->nv_index);
 
     return true;
@@ -131,13 +131,13 @@ static bool init(int argc, char* argv[], tpm_nvrelease_ctx *ctx) {
             }
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -80,7 +80,7 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
                 ctx->data_size > MAX_NV_BUFFER_SIZE ?
                 MAX_NV_BUFFER_SIZE : ctx->data_size;
 
-        LOG_INFO("The data(size=%d) to be written:\n", nv_write_data.t.size);
+        LOG_INFO("The data(size=%d) to be written:", nv_write_data.t.size);
 
         UINT16 i;
         for (i = 0; i < nv_write_data.t.size; i++) {
@@ -169,13 +169,13 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }
@@ -183,7 +183,7 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
     ctx->data_size = MAX_NV_INDEX_SIZE;
     result = files_load_bytes_from_file(ctx->input_file, ctx->nv_buffer, &ctx->data_size);
     if (!result) {
-        LOG_ERR("Failed to read data from %s\n", ctx->input_file);
+        LOG_ERR("Failed to read data from %s", ctx->input_file);
         return -false;
     }
 

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -210,7 +210,7 @@ static bool check_pcr_selection(listpcr_context *context) {
 
         if (j >= cap_data->data.assignedPCR.count) {
             const char *alg_name = tpm2_alg_util_algtostr(pcr_sel->pcrSelections[i].hash);
-            LOG_WARN("Ignore unsupported bank/algorithm: %s(0x%04x)\n", alg_name, pcr_sel->pcrSelections[i].hash);
+            LOG_WARN("Ignore unsupported bank/algorithm: %s(0x%04x)", alg_name, pcr_sel->pcrSelections[i].hash);
             pcr_sel->pcrSelections[i].hash = 0; //mark it as to be removed
         }
     }
@@ -241,7 +241,7 @@ static bool show_pcr_values(listpcr_context *context) {
                 continue;
             }
             if (vi >= context->pcrs.count || di >= context->pcrs.pcr_values[vi].count) {
-                LOG_ERR("Something wrong, trying to print but nothing more\n");
+                LOG_ERR("Something wrong, trying to print but nothing more");
                 return false;
             }
 
@@ -313,7 +313,7 @@ static bool get_banks(listpcr_context *context) {
             &more_data, capability_data, 0);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR(
-                "GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n",
+                "GetCapability: Get PCR allocation status Error. TPM Error:0x%x......",
                 rval);
         return false;
     }
@@ -403,10 +403,10 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
             s_flag = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             goto error;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             goto error;
         }
     }

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -231,7 +231,7 @@ static bool show_pcr_values(listpcr_context *context) {
         const char *alg_name = tpm2_alg_util_algtostr(
                 context->pcr_selections.pcrSelections[i].hash);
 
-        printf("\nBank/Algorithm: %s(0x%04x)\n", alg_name,
+        TOOL_OUTPUT("\nBank/Algorithm: %s(0x%04x)\n", alg_name,
                 context->pcr_selections.pcrSelections[i].hash);
 
         UINT32 pcr_id;
@@ -245,11 +245,11 @@ static bool show_pcr_values(listpcr_context *context) {
                 return false;
             }
 
-            printf("PCR_%02d:", pcr_id);
+            TOOL_OUTPUT("PCR_%02d:", pcr_id);
             int k;
             for (k = 0; k < context->pcrs.pcr_values[vi].digests[di].t.size; k++)
-                printf(" %02x", context->pcrs.pcr_values[vi].digests[di].t.buffer[k]);
-            printf("\n");
+                TOOL_OUTPUT(" %02x", context->pcrs.pcr_values[vi].digests[di].t.buffer[k]);
+            TOOL_OUTPUT("\n");
 
             if (context->output_file != NULL
                     && fwrite(context->pcrs.pcr_values[vi].digests[di].t.buffer,
@@ -330,13 +330,13 @@ static bool get_banks(listpcr_context *context) {
 
 static void show_banks(tpm2_algorithm *g_banks) {
 
-    printf("Supported Bank/Algorithm:");
+    TOOL_OUTPUT("Supported Bank/Algorithm:");
     int i;
     for (i = 0; i < g_banks->count; i++) {
         const char *alg_name = tpm2_alg_util_algtostr(g_banks->alg[i]);
-        printf(" %s(0x%04x)", alg_name, g_banks->alg[i]);
+        TOOL_OUTPUT(" %s(0x%04x)", alg_name, g_banks->alg[i]);
     }
-    printf("\n");
+    TOOL_OUTPUT("\n");
 }
 
 int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
@@ -390,7 +390,6 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
                         optarg, strerror(errno));
                 goto error;
             }
-            /* XXX Should o option only print to output file and nothing to stdout? */
             break;
         case 'L':
             if (!pcr_parse_selections(optarg, &context.pcr_selections)) {

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -407,13 +407,13 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
              is_auth_session = true;
              break;
        case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return 1;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return 1;
 	default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return 1;
         }
     };

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -173,13 +173,13 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
              }
              break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -148,13 +148,13 @@ static bool init(int argc, char *argv[], tpm_rsaencrypt_ctx *ctx) {
             flags.c = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     };

--- a/tools/tpm2_send_command.c
+++ b/tools/tpm2_send_command.c
@@ -136,13 +136,13 @@ static bool init(tpm2_send_command_ctx *ctx, int argc, char *argv[]) {
             ctx->output = open_file(optarg, "wb");
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -274,13 +274,13 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
             }
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -182,13 +182,13 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
             flags.F = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             return false;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             return false;
         default:
-            LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
             return false;
         }
     }
@@ -214,7 +214,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
                                         raw_pcrs_file, &pcr_digest, true,
                                         tpm2_policy_pcr_build);
         if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("Building PCR policy failed: 0x%x\n", rval);
+            LOG_ERR("Building PCR policy failed: 0x%x", rval);
             return false;
         }
 
@@ -244,7 +244,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     }
 
     if (!unseal_and_save(&ctx)) {
-        LOG_ERR("Unseal failed!\n");
+        LOG_ERR("Unseal failed!");
         return 1;
     }
 
@@ -252,7 +252,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
         TPM_RC rval = Tss2_Sys_FlushContext(ctx.sapi_context,
                                             ctx.policy_session->sessionHandle);
         if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("Failed Flush Context: 0x%x\n", rval);
+            LOG_ERR("Failed Flush Context: 0x%x", rval);
             return 1;
         }
 

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -95,7 +95,7 @@ static bool verify_signature(tpm2_verifysig_ctx *ctx) {
     rval = Tss2_Sys_VerifySignature(ctx->sapi_context, ctx->keyHandle, NULL,
             &ctx->msgHash, &ctx->signature, &validation, &sessionsDataOut);
     if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Tss2_Sys_VerifySignature failed, error code: 0x%x\n", rval);
+        LOG_ERR("Tss2_Sys_VerifySignature failed, error code: 0x%x", rval);
         return false;
     }
 
@@ -199,7 +199,7 @@ static bool init(tpm2_verifysig_ctx *ctx) {
         int rc = tpm_hash_compute_data(ctx->sapi_context, msg->buffer, msg->size,
                 ctx->halg, &ctx->msgHash);
         if (rc) {
-            LOG_ERR("Compute message hash failed!\n");
+            LOG_ERR("Compute message hash failed!");
             goto err;
         }
     }
@@ -285,10 +285,10 @@ static bool handle_options_and_init(int argc, char *argv[], tpm2_verifysig_ctx *
             ctx->flags.key_context = 1;
             break;
         case ':':
-            LOG_ERR("Argument %c needs a value!\n", optopt);
+            LOG_ERR("Argument %c needs a value!", optopt);
             break;
         case '?':
-            LOG_ERR("Unknown Argument: %c\n", optopt);
+            LOG_ERR("Unknown Argument: %c", optopt);
             break;
             /* no default */
         }


### PR DESCRIPTION
Currently the tools only have options to set two different log levels, -V to print all the log levels or not passing an option to only print error messages.

But users may want more fine grained control on what is printed by the tools, for example printing debug information but without the file and line numbers or to only print warning and error messages.

The latter is useful if the tools are used by scripts, which otherwise will have to redirect the tools standard output to /dev/null or other tricks to avoid cluttering the scripts output.

For example in the shell scripts where I'm using the tpm2-tools, I need to do things like this:

```
if ! tpm2_createprimary -A "$auth" -g "$hash" -G "$key" -C "$primary_context" > /dev/null; then
```
Because the tpm2_createprimary tool prints some information that is not relevant for the user of the script.

I thought that it would be nice to have a quiet option that prevents the tool to print any output, so instead I can have this:

```
if ! tpm2_createprimary -Q -A "$auth" -g "$hash" -G "$key" -C "$primary_context"; then
```

So this patch improves the log message support, by adding a debug and quiet options to provide this control for log levels. It also makes the default log level to be info, that way info, warning and error messages are printed if no option is used.