### PR TITLE
tpm2_dump_capability: Display specification minor version correctly

### DIFF
--- a/tools/tpm2_dump_capability.c
+++ b/tools/tpm2_dump_capability.c
@@ -208,7 +208,7 @@ dump_tpm_properties_fixed (TPMS_TAGGED_PROPERTY properties[],
             printf ("TPM_PT_LEVEL:               %d\n", value);
             break;
         case TPM_PT_REVISION:
-            printf ("TPM_PT_REVISION:            %.2f\n", (float)(value / 100));
+            printf ("TPM_PT_REVISION:            %.2f\n", (float)value / 100);
             break;
         case TPM_PT_DAY_OF_YEAR:
             printf ("TPM_PT_DAY_OF_YEAR:         0x%08x\n", value);


### PR DESCRIPTION
value needs to be converted to float before doing the division, otherwise the minor version will be truncated to zero.