### PR TITLE
coveralls: fix uploads

### DIFF
--- a/.ci/coveralls-upload.sh
+++ b/.ci/coveralls-upload.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 
 if [ "$ENABLE_COVERAGE" != "true" ]; then
-  echo "ENABLE_COVERAGE not true, exiting..."
+  echo "ENABLE_COVERAGE not true, got "$ENABLE_COVERAGE""
+  echo "Exiting..."
   exit 0
 fi
 
-if [ -n "$COVERALLS_REPO_TOKEN" ]; then
-  echo "COVERALLS_REPO_TOKEN set"
-else
+if [ -z "$COVERALLS_REPO_TOKEN" ]; then
   echo "COVERALLS_REPO_TOKEN *not* set"
-  exit 1
+  exit 0
 fi
+
+echo "COVERALLS_REPO_TOKEN set"
 
 coveralls --build-root=build --gcov-options '\-lp'
 exit $?

--- a/.ci/travis-build-and-run-tests.sh
+++ b/.ci/travis-build-and-run-tests.sh
@@ -96,4 +96,7 @@ PATH=$(pwd)/../../build/tools:${PATH} ./test_all.sh
 # done go back to tpm2-tools directory
 popd
 
+# upload coveralls results
+./.ci/coveralls-upload.sh
+
 exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,3 @@ script:
 
 after_failure:
    - cat build/test-suite.log
-
-after_success:
-  - ./.ci/coveralls-upload.sh


### PR DESCRIPTION
Coveralls was not being updated as ENABLE_COVERAGE was exported in
a seperate environment and not preserved when invoking the coveralls
upload script. Move the coveralls upload invocation within that
environment.

Signed-off-by: William Roberts <william.c.roberts@intel.com>