### PR TITLE
man pages: include some clarifications and fix some typos

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -264,7 +264,8 @@ man8_MANS = \
 MAN_DEPS := man/common-options.troff man/tcti-options.troff \
            man/tcti-environment.troff man/alg-common.troff \
            man/hash-alg-common.troff man/object-alg-common.troff \
-           man/sign-alg-common.troff man/password-fmt-common.troff
+           man/sign-alg-common.troff man/password-fmt-common.troff \
+           man/alg-notes-common.troff
 
 man/man8/%.8 : man/%.8.in $(MAN_DEPS)
 	rm -f $@
@@ -291,6 +292,8 @@ endif
 	    -e '/@SIGN_ALG_COMMON_INCLUDE@/d' \
 	    -e '/@PASSWORD_FORMAT_COMMON_INCLUDE@/r man/password-fmt-common.troff' \
 	    -e '/@PASSWORD_FORMAT_COMMON_INCLUDE@/d' \
+	    -e '/@ALG_NOTES_COMMON_INCLUDE@/r man/alg-notes-common.troff' \
+	    -e '/@ALG_NOTES_COMMON_INCLUDE@/d' \
 	    < $< >> $@
 
 CLEANFILES = $(man8_MANS)

--- a/man/alg-common.troff
+++ b/man/alg-common.troff
@@ -1,4 +1,4 @@
-Options tha take algorithms support "nice-names". Nice names, like sha1 can be
+Options that take algorithms support "nice-names". Nice names, like sha1 can be
 used in place of the raw hex for sha1: 0x4. The nice names are converted by
 stripping the leading TPM_ALG_ from the Algorithm Name field and converting
 it to lower case. For instance TPM_ALG_SHA3_256 becomes sha3_256.

--- a/man/alg-notes-common.troff
+++ b/man/alg-notes-common.troff
@@ -1,0 +1,9 @@
+The properties of the generated keys are currently fixed to the following values:
+.PP
+For TPM_ALG_RSA the key length is 2048 bit. The public key exponent is 2^16 +1.
+.PP
+For TPM_ALG_SYMCIPHER the symmetric key is AES 128 bit.
+.PP
+For TPM_ALG_ECC the curve parameters are TPM_ECC_NIST_P256.
+.PP
+For TPM_ALG_KEYEDHASH the algorithm is SHA256.

--- a/man/tpm2_akparse.8.in
+++ b/man/tpm2_akparse.8.in
@@ -40,10 +40,7 @@ file inputFile, and output the key into file akKeyFile.
 parse the algorithm and key values in TPM2B_PUBLIC struct which input via
 file inputFile, and output the key into file akKeyFile.
 .PP
-The output file will start with a 2 byte algorithm identifier followed by one
-or more public key parts. Each public key part will start with a 2 byte
-length header followed by the actual data. Both header fields are stored in
-big endian byte order.
+The output file will be in an opaque implementation defined format.
 .SH OPTIONS
 .TP
 \fB\-f\fR

--- a/man/tpm2_akparse.8.in
+++ b/man/tpm2_akparse.8.in
@@ -39,6 +39,11 @@ file inputFile, and output the key into file akKeyFile.
 .B tpm2_akparse
 parse the algorithm and key values in TPM2B_PUBLIC struct which input via
 file inputFile, and output the key into file akKeyFile.
+.PP
+The output file will start with a 2 byte algorithm identifier followed by one
+or more public key parts. Each public key part will start with a 2 byte
+length header followed by the actual data. Both header fields are stored in
+big endian byte order.
 .SH OPTIONS
 .TP
 \fB\-f\fR

--- a/man/tpm2_getpubak.8.in
+++ b/man/tpm2_getpubak.8.in
@@ -69,7 +69,7 @@ specifies the handle of EK (hex).
 specifies the handle used to make AK  persistent (hex). 
 .TP
 -\fB\-g ,\-\-alg\fR
--specifies the algorithm type of AK.
+specifies the algorithm type of AK.
 @ALG_COMMON_INCLUDE@
 @OBJECT_ALG_COMMON_INCLUDE@
 .TP
@@ -82,13 +82,17 @@ Like -g, but specifies the algorithm of sign.
 @SIGN_ALG_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
-specifies the file used to save the public  portion of AK. 
+specifies the file used to save the public  portion of AK. This will be a
+binary data structure corresponding to the TPM2B_PUBLIC struct in the
+specification.
 .TP
 \fB\-n ,\-\-akName\fR
 specifies the file used to save the ak name.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@
+.SH NOTES
+@ALG_NOTES_COMMON_INCLUDE@
 .SH EXAMPLES
 .B tpm2_getpubak
 .PP

--- a/man/tpm2_getpubek.8.in
+++ b/man/tpm2_getpubek.8.in
@@ -71,13 +71,17 @@ specifies the algorithm type of EK.
 @OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
-specifies the file used to save the public  portion of EK. 
+specifies the file used to save the public  portion of EK. This will be a
+binary data structure corresponding to the TPM2B_PUBLIC struct in the
+specification.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@
+.SH NOTES
+@ALG_NOTES_COMMON_INCLUDE@
 .SH EXAMPLES
 .B tpm2_getpubek
 .PP

--- a/man/tpm2_quote.8.in
+++ b/man/tpm2_quote.8.in
@@ -49,7 +49,7 @@ AK handle's Password.
 @PASSWORD_FORMAT_COMMON_INCLUDE@
 .TP
 \fB\-l ,\-\-idList\fR
-The list of selected PCRs' ids, 0~23
+The comma separated list of selected PCRs' ids, 0~23 e.g. "4,5,6"
 .TP
 \fB\-g ,\-\-algorithm\fR
 The algorithm id.
@@ -57,7 +57,10 @@ The algorithm id.
 @OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-L ,\-\-selList\fR
-The list of pcr banks and selected PCRs' ids   (0~23) for each bank 
+The list of pcr banks and selected PCRs' ids   (0~23) for each bank. Format is
+<BANK>:<PCR>[,<PCR>]; multiple banks may be separated by '+'. For example
+sha:3,4+sha256:5,6 will select PCRs 3 and 4 from the SHA bank and PCRs 5 and 6
+from the SHA256 bank.
 .TP
 \fB\-o ,\-\-outFile\fR
 output file path, recording the two structures  output by tpm2_quote function 
@@ -66,7 +69,8 @@ output file path, recording the two structures  output by tpm2_quote function
 passwords given by any options are hex format.
 .TP
 \fB\-q ,\-\-qualifyData\fR
-Data given as a Hex string to qualify the  quote, optional.
+Data given as a Hex string to qualify the  quote, optional. This is typically
+used to add a nonce against replay attacks.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.


### PR DESCRIPTION
For new users it is helpful to know which key lengths and parameters are
actually produced by tpm2_getpub*, also what kind of data is output for
public key portions and by tpm2_akparse.