### PR TITLE
Improve interoperability with OpenSSL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,8 @@ man8_MANS = \
     man/man8/tpm2_rc_decode.8 \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8 \
-    man/man8/tpm2_pcrextend.8
+    man/man8/tpm2_pcrextend.8 \
+    man/man8/tpm2_convert_key.8
 
 MAN_DEPS := man/common-options.troff man/tcti-options.troff \
            man/tcti-environment.troff man/alg-common.troff \

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,7 +84,8 @@ bin_PROGRAMS = \
     tools/tpm2_unseal \
     tools/tpm2_dictionarylockout \
     tools/tpm2_createpolicy \
-    tools/tpm2_pcrextend
+    tools/tpm2_pcrextend \
+    tools/tpm2_convert_key
 
 noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = \
@@ -162,6 +163,7 @@ tools_tpm2_unseal_SOURCES = tools/tpm2_unseal.c $(TOOL_SRC)
 tools_tpm2_dictionarylockout_SOURCES = tools/tpm2_dictionarylockout.c $(TOOL_SRC)
 tools_tpm2_createpolicy_SOURCES = tools/tpm2_createpolicy.c $(TOOL_SRC)
 tools_tpm2_pcrextend_SOURCES = tools/tpm2_pcrextend.c $(TOOL_SRC)
+tools_tpm2_convert_key_SOURCES = tools/tpm2_convert_key.c $(TOOL_SRC)
 
 # rc_decode does not use common main, since it does not need a dynamic TCTI.
 tools_tpm2_rc_decode_SOURCES = lib/rc-decode.c tools/tpm2_rc_decode.c

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -301,30 +301,38 @@ bool pcr_parse_digest_list(char **argv, int len,
     return true;
 }
 
-bool tpm2_extract_plain_signature(UINT8 **buffer, UINT16 *size,
-    TPMT_SIGNATURE *signature) {
+UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature) {
 
-    *buffer = NULL;
+    UINT8 *buffer = NULL;
     *size = 0;
 
     switch (signature->sigAlg) {
     case TPM_ALG_RSASSA:
         *size = sizeof((*signature).signature.rsassa.sig.t.buffer);
-        *buffer = malloc(*size);
-        memcpy(*buffer, (*signature).signature.rsassa.sig.t.buffer, *size);
+        buffer = malloc(*size);
+        if(! buffer) {
+            goto nomem;
+        }
+        memcpy(buffer, (*signature).signature.rsassa.sig.t.buffer, *size);
         break;
     case TPM_ALG_HMAC: {
         TPMU_HA *hmac_sig = &((*signature).signature.hmac.digest);
         *size = tpm2_alg_util_get_hash_size((*signature).signature.hmac.hashAlg);
-        *buffer = malloc(*size);
-        memcpy(*buffer, &(hmac_sig->na), *size);
+        buffer = malloc(*size);
+        if(! buffer) {
+            goto nomem;
+        }
+        memcpy(buffer, &(hmac_sig->na), *size);
         break;
     }
     case TPM_ALG_ECDSA: {
         const size_t ECC_PAR_LEN = sizeof(TPM2B_ECC_PARAMETER);
         *size = ECC_PAR_LEN * 2;
-        *buffer = malloc(*size);
-        memcpy(*buffer,
+        buffer = malloc(*size);
+        if(! buffer) {
+            goto nomem;
+        }
+        memcpy(buffer,
             (UINT8*)&((*signature).signature.ecdsa.signatureR),
             ECC_PAR_LEN
         );
@@ -337,8 +345,11 @@ bool tpm2_extract_plain_signature(UINT8 **buffer, UINT16 *size,
     default:
         LOG_ERR("%s: unknown signature scheme: 0x%x", __func__,
             signature->sigAlg);
-        return false;
+        return NULL;
     }
 
-    return true;
+    return buffer;
+nomem:
+    LOG_ERR("%s: couldn't allocate memory", __func__);
+    return NULL;
 }

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -132,16 +132,13 @@ UINT16 tpm2_alg_util_get_hash_size(TPMI_ALG_HASH id);
 
 /**
  * Extracts the plain signature data without any headers
- * @param buffer
- *  Will be malloc()'d and filled with the extracted signature. Needs to be
- *  free()'d by the caller.
  * @param size
  *  Will receive the number of bytes stored in buffer.
  * @signature The actual signature struct to extract the plain signature from.
  * @return
- *  true on success, false on error. Errors will be logged via LOG_ERR.
+ *  Returns a buffer filled with the extracted signature or NULL on error.
+ *  Needs to be free()'d by the caller.
  */
-bool tpm2_extract_plain_signature(UINT8 **buffer, UINT16 *size,
-    TPMT_SIGNATURE *signature);
+UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature);
 
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -130,4 +130,18 @@ bool pcr_parse_digest_list(char **argv, int len,
  */
 UINT16 tpm2_alg_util_get_hash_size(TPMI_ALG_HASH id);
 
+/**
+ * Extracts the plain signature data without any headers
+ * @param buffer
+ *  Will be malloc()'d and filled with the extracted signature. Needs to be
+ *  free()'d by the caller.
+ * @param size
+ *  Will receive the number of bytes stored in buffer.
+ * @signature The actual signature struct to extract the plain signature from.
+ * @return
+ *  true on success, false on error. Errors will be logged via LOG_ERR.
+ */
+bool tpm2_extract_plain_signature(UINT8 **buffer, UINT16 *size,
+    TPMT_SIGNATURE *signature);
+
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/man/tpm2_convert_key.8.in
+++ b/man/tpm2_convert_key.8.in
@@ -1,0 +1,62 @@
+.\" Copyright (c) 2016, Intel Corporation
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\" 1. Redistributions of source code must retain the above copyright notice,
+.\" this list of conditions and the following disclaimer.
+.\"
+.\" 2. Redistributions in binary form must reproduce the above copyright notice,
+.\" this list of conditions and the following disclaimer in the documentation
+.\" and/or other materials provided with the distribution.
+.\"
+.\" 3. Neither the name of Intel Corporation nor the names of its contributors
+.\" may be used to endorse or promote products derived from this software without
+.\" specific prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+.\" THE POSSIBILITY OF SUCH DAMAGE.
+.TH tpm2_convert_key 8 "August 2017" Intel "tpm2-tools"
+.SH NAME
+tpm2_convert_key\ - convert the public key data returned by
+.RB tpm2_akparse (8)
+into OpenSSL PEM or DER format.
+.SH SYNOPSIS
+.B tpm2_convert_key [ COMMON OPTIONS ] [ \fB\-f\fR|\fB\-k\fR|\fB\-t\fR ]
+.SH DESCRIPTION
+Reads the public key input file (-f) which is expected to be in the format
+created by
+.RB tpm2_akparse (8).
+Convert the public key into the requested format and write it to the public key
+output file (-k).
+.SH OPTIONS
+.TP
+\fB\-f\fR
+Specifies the input file containing the public key to be converted
+.TP
+\fB\-k\fR
+Specifies the file used to save the converted public key
+.TP
+\fB\-t\fR
+Specifies the target public key format; currently PEM for OpenSSL PEM format
+or DER for OpenSSL DER format
+@COMMON_OPTIONS_INCLUDE@
+.SH EXAMPLES
+.B tpm2_convert_key
+.PP
+.nf
+.RS
+tpm2_convert_key -t PEM -f ak.key -k ak.pem
+tpm2_convert_key -t DER -f ak.key -k ak.der
+.RE
+.fi

--- a/man/tpm2_convert_key.8.in
+++ b/man/tpm2_convert_key.8.in
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2016, Intel Corporation
+.\" Copyright (c) 2017, Intel Corporation
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without

--- a/man/tpm2_quote.8.in
+++ b/man/tpm2_quote.8.in
@@ -62,6 +62,18 @@ The list of pcr banks and selected PCRs' ids   (0~23) for each bank
 \fB\-o ,\-\-outFile\fR
 output file path, recording the two structures  output by tpm2_quote function 
 .TP
+\fB\-r ,\-\-plainSig\fR
+like -o but here only the plain signature data will be stored. This can be
+used by other tools like
+.RB openssl(1)
+for verification.
+.TP
+\fB\-t ,\-\-plainQuote\fR
+like -o but here only the plain quote message data will be stored. This is the
+structure that is actually signed. This can be used by other tools like
+.RB openssl(1)
+for verification.
+.TP
 \fB\-X ,\-\-passwdInHex\fR
 passwords given by any options are hex format.
 .TP

--- a/man/tpm2_sign.8.in
+++ b/man/tpm2_sign.8.in
@@ -74,6 +74,12 @@ the ticket file, containning the validation  structure, optional
 \fB\-s ,\-\-sig\fR
 the signature file, record the signature structure
 .TP
+\fB\-r ,\-\-plain-sig\fR
+like -s but here only the plain signature data will be stored. This can be
+used by other tools like
+.RB openssl (1)
+for verification.
+.TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.
 @COMMON_OPTIONS_INCLUDE@

--- a/tools/tpm2_convert_key.c
+++ b/tools/tpm2_convert_key.c
@@ -239,7 +239,6 @@ static bool write_key(
 
     FILE *f = NULL;
     bool ret = false;
-    bool tmp_res = false;
     int ssl_res = -1;
     RSA *ssl_rsa_key = RSA_new();
     // openssl expects this in network byte order
@@ -258,12 +257,6 @@ static bool write_key(
         LOG_ERR("Failed to convert input data to SSL internal format: \"%s\"",
             strerror(errno)
         );
-        goto out;
-    }
-
-    tmp_res = files_does_file_exist(outfile);
-
-    if (tmp_res) {
         goto out;
     }
 

--- a/tools/tpm2_convert_key.c
+++ b/tools/tpm2_convert_key.c
@@ -1,0 +1,414 @@
+//**********************************************************************;
+// Copyright (c) 2015, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/rsa.h>
+#include <openssl/pem.h>
+
+#include <getopt.h>
+
+#include "files.h"
+#include "log.h"
+#include "main.h"
+#include "options.h"
+#include "tpm2_util.h"
+
+/*
+ * This program takes a key file as created by `tpm2_akparse` as input and
+ * converts it into OpenSSL PEM or DER format public keys.
+ *
+ * This is currently limited to RSA public keys but might be extended to other
+ * key types in the future.
+ */
+
+// holds all the custom command line parameters for our purposes
+typedef struct tpm_convert_key_ctx tpm_convert_key_ctx;
+struct tpm_convert_key_ctx {
+    char *key_input_file_path;
+    char *key_output_file_path;
+    char *key_output_format;
+};
+
+// holds a single key blob as found in the input file
+struct key_blob {
+    UINT16 length;
+    UINT8  *data;
+};
+
+#define MAX_KEY_BLOBS 8
+
+// holds the complete information as found in the input file
+struct key_data {
+    UINT16 alg_type;
+    size_t num_blobs;
+    struct key_blob blobs[MAX_KEY_BLOBS];
+};
+
+typedef enum {
+    FMT_PEM,
+    FMT_DER,
+    FMT_INVAL
+} convert_format;
+
+// reads just the algorithm type identifier from the given file and returns it
+// in the correct endianess. error handling included.
+static bool read_alg_type(FILE *f, UINT16 *alg_type) {
+
+    if (fread(alg_type, 2, 1, f) != 1) {
+        LOG_ERR("Could not read algtype from input file: \"%s\".",
+            (feof(f) ? "Premature end of file" : strerror(errno))
+        );
+
+        return false;
+    }
+
+    // convert byte order
+    *alg_type = tpm2_util_ntoh_16(*alg_type);
+
+    return true;
+}
+
+// frees any dynamically allocated data in the given key_data struct
+static void free_keys(struct key_data *data) {
+    size_t i;
+    struct key_blob *blob;
+
+    for (i = 0; i < data->num_blobs; i++) {
+        blob = &(data->blobs[i]);
+        free(blob->data);
+        blob->data = NULL;
+    }
+}
+// parse all found blob parts from the given file and add them to the key_data
+// struct. error handling included.
+// on true return the caller is responsible for freeing data
+static bool read_blobs(FILE *f, struct key_data *data) {
+    const size_t MAX_LENGTH = 8192;
+    struct key_blob blob;
+    bool ret = false;
+
+    // read in a variable number of blobs until EOF or error occurs
+    while (true) {
+
+        if (fread(&blob.length, 2, 1, f) != 1) {
+            if (!feof(f)) {
+                LOG_ERR("Could not read key blob length from input file: \"%s\".",
+                    strerror(errno)
+                );
+
+                goto out;
+            }
+
+            ret = true;
+            break;
+        }
+
+        // correct byte order
+        blob.length = tpm2_util_ntoh_16(blob.length);
+
+        if (blob.length > MAX_LENGTH) {
+            LOG_ERR("Excess length key blob of %d bytes encountered",
+                blob.length
+            );
+
+            goto out;
+        }
+        else if (data->num_blobs == MAX_KEY_BLOBS) {
+            LOG_ERR("Maximum number of key blobs %d exceeded.", MAX_KEY_BLOBS);
+            goto out;
+        }
+
+        blob.data = malloc(blob.length);
+
+        if (fread(blob.data, blob.length, 1, f) != 1) {
+            LOG_ERR("Failed to read key blob nr. %zd: \"%s\".",
+                data->num_blobs + 1,
+                (feof(f) ? "Premature end of file" : strerror(errno))
+            );
+
+            free(blob.data);
+
+            goto out;
+        }
+
+        data->blobs[data->num_blobs] = blob;
+        data->num_blobs ++;
+    }
+
+out:
+
+    if (ret == false) {
+        free_keys(data);
+    }
+
+    return ret;
+}
+
+/*
+ * Read the binary structure from infile and put it into the given blob output
+ * parameter. This expects the structure as output by tpm2_akparse.
+ */
+static bool read_key(const char *infile, struct key_data *data) {
+    FILE *f;
+    bool ret = false;
+
+    memset(data, 0, sizeof(struct key_data));
+
+    f = fopen(infile, "rb");
+    if (!f) {
+        LOG_ERR("Could not open input file \"%s\": \"%s\".",
+            infile,
+            strerror(errno)
+        );
+
+        return false;
+    }
+
+    if (read_alg_type(f, &data->alg_type) != true)
+        goto out;
+    else if (read_blobs(f, data) != true)
+        goto out;
+
+    if (data->num_blobs == 0) {
+        LOG_ERR("Could not read any key blobs");
+        goto out;
+    }
+
+    ret = true;
+
+out:
+    fclose(f);
+
+    return ret;
+}
+
+// converts the information found in the key_data struct into the
+// corresponding OpenSSL format, storing the result in outfile.
+static bool write_key(
+    const char *outfile, struct key_data *data, convert_format format) {
+
+    FILE *f = NULL;
+    bool ret = false;
+    RSA *ssl_rsa_key = RSA_new();
+    // openssl expects this in network byte order
+    UINT32 exponent = tpm2_util_hton_32(RSA_DEFAULT_PUBLIC_EXPONENT);
+
+    ssl_rsa_key->n = BN_bin2bn(
+        (data->blobs[0]).data,
+        (data->blobs[0]).length,
+        NULL
+    );
+    ssl_rsa_key->e = BN_bin2bn(
+        (void*)&exponent, sizeof(exponent), NULL
+    );
+
+    if (!ssl_rsa_key->n || !ssl_rsa_key->e) {
+        LOG_ERR("Failed to convert input data to SSL internal format: \"%s\"",
+            strerror(errno)
+        );
+        goto out;
+    }
+
+    if (files_does_file_exist(outfile)) {
+        goto out;
+    }
+
+    f = fopen(outfile, "wb+");
+    if (!f) {
+        LOG_ERR("Could not open output file \"%s\": \"%s\".",
+            outfile,
+            strerror(errno)
+        );
+        goto out;
+    }
+
+    switch(format) {
+    case FMT_PEM:
+        if (PEM_write_RSA_PUBKEY(f, ssl_rsa_key) <= 0) {
+            LOG_ERR("OpenSSL PEM conversion failed: \"%s\"", strerror(errno));
+            goto out;
+        }
+        break;
+    case FMT_DER:
+        if (i2d_RSA_PUBKEY_fp(f, ssl_rsa_key) <= 0) {
+            LOG_ERR("OpenSSL DER conversion failed: \"%s\"", strerror(errno));
+            goto out;
+        }
+        break;
+    default:
+        LOG_ERR("Unexpected output format encountered");
+        goto out;
+    }
+
+    ret = true;
+
+out:
+    if (f)
+        fclose(f);
+    RSA_free(ssl_rsa_key);
+    return ret;
+}
+
+static convert_format get_format(const char *format) {
+
+    if (strcmp(format, "PEM") == 0)
+        return FMT_PEM;
+    else if (strcmp(format, "DER") == 0)
+        return FMT_DER;
+
+    LOG_ERR("Invalid conversion format \"%s\" encountered", format);
+
+    return FMT_INVAL;
+}
+
+// performs the complete program logic using the command line information
+// assembled in ctx
+static bool convert_key(const struct tpm_convert_key_ctx *ctx) {
+
+    struct key_data data;
+    convert_format format = get_format(ctx->key_output_format);
+    bool ret = false;
+
+    if (format == FMT_INVAL)
+        return false;
+    else if (! read_key(ctx->key_input_file_path, &data))
+        return false;
+
+    if (data.alg_type != TPM_ALG_RSA) {
+        LOG_ERR("Unsupported algorithm type 0x%04x in input file.",
+            data.alg_type
+        );
+
+        goto out;
+    }
+    else if (data.num_blobs != 1) {
+        LOG_ERR("Unexpected number of key blobs encountered: %zd",
+            data.num_blobs);
+
+        goto out;
+    }
+
+    ret = write_key(ctx->key_output_file_path, &data, format);
+
+out:
+    free_keys(&data);
+
+    return ret;
+}
+
+static bool init(int argc, char *argv[], tpm_convert_key_ctx *ctx) {
+
+    struct option options[] = {
+            { "keyInFile",    required_argument, NULL, 'k' },
+            { "keyOutFile",   required_argument, NULL, 'f' },
+            { "keyOutFormat", required_argument, NULL, 't' },
+            { NULL,           no_argument,       NULL, '\0' }
+    };
+
+    if (argc <=1 || argc > (int) (2 * sizeof(options) / sizeof(struct option))) {
+        showArgMismatch(argv[0]);
+        return false;
+    }
+
+    int opt;
+    while ((opt = getopt_long(argc, argv, "f:k:t:hv", options, NULL)) != -1) {
+        switch (opt) {
+        case 'f':
+            if (!optarg) {
+                LOG_ERR("Please specify the file containing the public key");
+                return false;
+            }
+            ctx->key_input_file_path = optarg;
+            break;
+        case 'k':
+            if (!optarg) {
+                LOG_ERR("Please specify the file where to save the converted public key");
+                return false;
+            }
+            ctx->key_output_file_path = optarg;
+            break;
+        case 't':
+            if (!optarg) {
+                LOG_ERR("Please specify the output file format");
+                return false;
+            }
+            ctx->key_output_format = optarg;
+            break;
+        case ':':
+            LOG_ERR("Argument %c needs a value!", optopt);
+            return false;
+        case '?':
+            LOG_ERR("Unknown Argument: %c", optopt);
+            return false;
+        default:
+            LOG_ERR("?? getopt returned character code 0%o ??", opt);
+            return false;
+        }
+    }
+
+    if (
+        !ctx->key_input_file_path ||
+        !ctx->key_output_file_path ||
+        !ctx->key_output_format) {
+        LOG_ERR("One or more required parameters missing.");
+        return false;
+    }
+
+    return true;
+}
+
+int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
+        TSS2_SYS_CONTEXT *sapi_context) {
+
+    /* opts is unused, avoid compiler warning */
+    (void)opts;
+    (void)sapi_context;
+    (void)envp;
+
+    struct tpm_convert_key_ctx ctx;
+
+    memset(&ctx, 0, sizeof(struct tpm_convert_key_ctx));
+
+    bool result = init(argc, argv, &ctx);
+    if (!result) {
+        return 1;
+    }
+
+    /* 0 on success, 1 on error */
+    return convert_key(&ctx) == true ? 0 : 1;
+}
+

--- a/tools/tpm2_convert_key.c
+++ b/tools/tpm2_convert_key.c
@@ -158,6 +158,10 @@ static bool read_blobs(FILE *f, struct key_data *data) {
         }
 
         blob.data = malloc(blob.length);
+        if(blob.data == NULL) {
+            LOG_ERR("Failed to allocate memory");
+            goto out;
+        }
         cnt = fread(blob.data, blob.length, 1, f);
 
         if (cnt != 1) {
@@ -297,8 +301,9 @@ static bool write_key(
     ret = true;
 
 out:
-    if (f)
+    if (f) {
         fclose(f);
+    }
     RSA_free(ssl_rsa_key);
     return ret;
 }
@@ -372,24 +377,12 @@ static bool init(int argc, char *argv[], tpm_convert_key_ctx *ctx) {
     while ((opt = getopt_long(argc, argv, "f:k:t:hv", options, NULL)) != -1) {
         switch (opt) {
         case 'f':
-            if (!optarg) {
-                LOG_ERR("Please specify the file containing the public key");
-                return false;
-            }
             ctx->key_input_file_path = optarg;
             break;
         case 'k':
-            if (!optarg) {
-                LOG_ERR("Please specify the file where to save the converted public key");
-                return false;
-            }
             ctx->key_output_file_path = optarg;
             break;
         case 't':
-            if (!optarg) {
-                LOG_ERR("Please specify the output file format");
-                return false;
-            }
             ctx->key_output_format = optarg;
             break;
         case ':':
@@ -404,10 +397,9 @@ static bool init(int argc, char *argv[], tpm_convert_key_ctx *ctx) {
         }
     }
 
-    if (
-        !ctx->key_input_file_path ||
-        !ctx->key_output_file_path ||
-        !ctx->key_output_format) {
+    if (!ctx->key_input_file_path ||
+            !ctx->key_output_file_path ||
+            !ctx->key_output_format) {
         LOG_ERR("One or more required parameters missing.");
         return false;
     }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -229,7 +229,7 @@ FILE* open_file(const char *path)
 bool write_file(FILE *fp, void *data, size_t len,
     const char *path, const char *label)
 {
-    if(fwrite(data, len, 1, fp) != 1)
+    if(files_write_bytes(fp, data, len) != true)
     {
         printf("OutFile: %s Write %s Data In Error!\n", path, label);
         fclose(fp);

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -274,8 +274,11 @@ int write_output_files(TPM2B_ATTEST *quoted, TPMT_SIGNATURE *signature)
         fp = open_file(outPlainSigFilePath);
         if(NULL == fp)
             return -7;
-        else if(!tpm2_extract_plain_signature(&buffer, &size, signature))
+        buffer = tpm2_extract_plain_signature(&size, signature);
+        if(!buffer)
+        {
             return -8;
+        }
         else if(write_file(fp, buffer, size,
             outPlainSigFilePath, "buffer") != true)
         {

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -170,8 +170,8 @@ static bool sign_and_save(tpm_sign_ctx *ctx) {
     if (ctx->outPlainFilePath) {
         UINT8 *buffer;
         UINT16 size;
-        result = tpm2_extract_plain_signature(&buffer, &size, &signature);
-        if (result) {
+        buffer = tpm2_extract_plain_signature(&size, &signature);
+        if (buffer != NULL) {
             result = files_save_bytes_to_file(ctx->outPlainFilePath, buffer, size);
             free(buffer);
         }


### PR DESCRIPTION
- a new tool `tpm2_convert_key` to convert the keys written by `tpm2_akparse` into OpenSSL PEM or DER format in a programmatical way
- new parameter `-r` for `tpm2_sign` for optionally writing the plain signature into a file that can be directly used by OpenSSL tools
- new parameter `-r` and `-t` for `tpm2_quote` for optionally writing the plain signature and plain quote message into separate files that can be directly used by OpenSSL tools