### PR TITLE
CHANGELOG: Document that new --quiet option was added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ next
 * installation into customized locations are now working, see issue #402 for details.
 * tpm2_pcrlist: renamed from tpm2_listpcrs.
 * tpm2_pcrextend: new tool for extending PCRs.
-* tpm2_getmanufec: -E option no longer reqiored, defaults to stdout.
+* tpm2_getmanufec: -E option no longer required, defaults to stdout.
 * tpm2_nvlist: Support for friendly nv attributes in output.
 * Support for friendly algorithm names for algorithm identifiers.
 * tpm2_nvread: The option, -s, or size option is no longer required.
@@ -23,7 +23,7 @@ next
 * tpm2_createprimary: add ability to create objects with policy based authorization.
 * tpm2_nvdefine: add ability to create nv indexes with policy based authorization.
 * Support Clang Build.
-* tpm2_unseal test uses endorsment hiearchy as platform hiearchy is unavailable on a
+* tpm2_unseal test uses endorsement hierarchy as platform hierarchy is unavailable on a
   real tpm.
 * Numerous cleanups and minor bug fixes.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 next
+* Make tpm2_{createprimary,create,load,pcrlist,hmac} tools to support the --quiet option.
+* Support for a --quiet option to suppress messages printed by tools to standard output.
 * tpm2_hmac: support for files greater than 1024 bytes, changes in options and arguments.
 * tpm2_hash: support for files greater than 1024 bytes, changes in options and arguments.
 * Install is now to bin vs sbin. Ensure that sbin tools get removed!


### PR DESCRIPTION
A new option was added to supress the tools output, but a note was not
added to the CHANGELOG.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>