### PR TITLE
tpm2_hash: Drop -I option in man page example

### DIFF
--- a/man/tpm2_hash.8.in
+++ b/man/tpm2_hash.8.in
@@ -70,6 +70,6 @@ file record the ticket, optional.
 .PP
 .nf
 .RS
-tpm2_hash -H <e|o|p|n> -g 0x004 -I <inputFilename> -o <hashFilename> -t <ticketFilename>
+tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
 .RE
 .fi


### PR DESCRIPTION
The commit 6388831 ("tpm2_hash: drop -I option") changed tpm2_hash tool
to get the data to hash from either the standard input or a file. So it
remove the -I option.

But forgot to update the example in the man page. While being there, do
as other examples in man pages and show a specific command instead of a
generic one.

Fixes: #441

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>