### PR TITLE
configure: Check for md2man-roff.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,11 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
+AC_CHECK_PROG([MD2MAN_ROFF],[md2man-roff],[yes])
+AS_IF(
+    [test "x${MD2MAN_ROFF}" == x"yes"],
+    [],
+    [AC_MSG_FAILURE([Required executable md2man-roff not found.])])
 PKG_CHECK_MODULES([SAPI],[sapi])
 # disable libtcti-device selectively (enabled by default)
 AC_ARG_WITH(


### PR DESCRIPTION
md2man-roff is required for the build to succeed. If it's missing
this commit will cause the configure script to fail with a helpful
error message.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>