### PR TITLE
build: Don't generate man pages from markdown if md2man-roff isn't found

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,8 +261,12 @@ man8_MANS = \
     man/man8/tpm2_rc_decode.8 \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8 \
-    man/man8/tpm2_pcrextend.8 \
+    man/man8/tpm2_pcrextend.8
+
+if HAVE_MD2MAN_ROFF
+    man8_MANS += \
     man/man8/tpm2_pcrevent.8
+endif
 
 MAN_DEPS := man/common-options.troff man/tcti-options.troff \
            man/tcti-environment.troff man/alg-common.troff \

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,12 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
+AC_CHECK_PROG([MD2MAN_ROFF],[md2man-roff],[yes])
+AS_IF(
+    [test "x${MD2MAN_ROFF}" == x"yes"],
+    [],
+    [AC_MSG_WARN([Required executable md2man-roff not found, some man pages will not be build])])
+AM_CONDITIONAL([HAVE_MD2MAN_ROFF],[test "x${MD2MAN_ROFF}" = "xyes"])
 PKG_CHECK_MODULES([SAPI],[sapi])
 # disable libtcti-device selectively (enabled by default)
 AC_ARG_WITH(


### PR DESCRIPTION
The md2man-roff tool is required to generate roff man pages from markdown
for some tools, but this may not be available on some systems. Instead of
making the build to fail, just don't attempt to generate these man pages.

Fixes: #447

Reported-by: Philip Tricca <philip.b.tricca@intel.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>