### PR TITLE
A couple of fixes for tpm2_getrandom tests

### DIFF
--- a/test/system/test_all.sh
+++ b/test/system/test_all.sh
@@ -63,6 +63,7 @@ test_wrapper test_tpm2_takeownership_all.sh
 test_wrapper test_tpm2_nv.sh
 test_wrapper test_tpm2_pcrlist.sh
 test_wrapper test_tpm2_getrandom.sh
+test_wrapper test_tpm2_getrandom_func.sh
 #test_wrapper test_tpm2_createprimary_all.sh
 #test_wrapper test_tpm2_create_all.sh
 test_wrapper test_tpm2_load.sh

--- a/test/system/test_tpm2_getrandom_func.sh
+++ b/test/system/test_tpm2_getrandom_func.sh
@@ -38,9 +38,8 @@ LOG_FILE=random_pass_count.log
  fi
 i=
 
-#for((i=1;i<=10;i++)); do
 for i in `seq 100`; do
-	tpm2_getrandom o random_"$i".out 32
+	tpm2_getrandom -o random_"$i".out 32
 	 if  [ $? != 0 ];then
 	  echo " create random_"$i".out fail, please check the environment or parameters!"
 	  exit 2


### PR DESCRIPTION
While porting the tpm2_getrandom tool to the new options parsing logic, I noticed that the test_tpm2_getrandom_func.sh has been broken for some time due a silly typo.

This pull request fix this issue and also adds the test to the test_all.sh coverage.