### PR TITLE
tpm2_getrandom: cleanup temporary files created by test

### DIFF
--- a/test/system/test_tpm2_getrandom_func.sh
+++ b/test/system/test_tpm2_getrandom_func.sh
@@ -33,9 +33,18 @@
 #this script for tpm2_getrandom verification 
 
 LOG_FILE=random_pass_count.log
+
+cleanup() {
  if [ -e "$LOG_FILE" ];then
   rm -f "$LOG_FILE"
+  rm -f random_*.out
  fi
+}
+
+trap cleanup EXIT
+
+cleanup
+
 i=
 
 for i in `seq 100`; do


### PR DESCRIPTION
The tpm2_getrandom_func test leaves a lot of temporary files around,
make sure those are cleaned up correctly when the script exits.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>