### PR TITLE
test: fix tpm2_nv.sh passing a hex number as head command -c argument

### DIFF
--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -134,7 +134,11 @@ fi
 large_file_name="nv.test_large_w"
 
 if [ ! -f $large_file_name ]; then
-  base64 /dev/urandom | head -c $large_file_size > $large_file_name
+  base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
+  if [ $? != 0 ];then
+    echo "creating large file $large_file_name failed"
+    exit 1
+  fi
 fi
 
 tpm2_nvwrite -x $nv_test_index -a $nv_auth_handle  -f $large_file_name


### PR DESCRIPTION
The test TPM_PT_NV_INDEX_MAX fixed TPM2 property to know the NV index data
area maximum size:

$ tpm2_dump_capability -c properties-fixed | grep TPM_PT_NV_INDEX_MAX | sed -r -e 's/.*(0x[0-9a-f]+)/\1/g'
0x00000800

And then passes this value to the head command as a -c option argument:

$ base64 /dev/urandom | head -c 0x00000800
head: invalid number of bytes: ‘0x00000800’

This is making the test to fail, but since the exit code for the mentioned
command is not checked, it's still reported as if the test succeed.

$ ./test_tpm2_nv.sh
70 6c 65 61 73 65 31 32 33 61 62 63 0a

000000: e8 5d ca 86 cc 7f 00 00 e8 5d ca 86 cc 7f 00 00  .].......]......
000010: 30 e0 87 5a 79 55 00 00 05 00 00 00 00 00 00 00  0..ZyU..........
  0. NV Index: 0x1500018
release the nv index OK!
head: invalid number of bytes: ‘0x00000800’
ERROR: Failed to read NVRAM area at index 0x1000000 (16777216). Error:0x14a
  0. NV Index: 0x1000000

$ echo $?
0

Fixes: #463

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>