### PR TITLE
Another set of tools ported to the new option handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ bin_PROGRAMS = \
     tools/tpm2_hmac \
     tools/tpm2_listpersistent \
     tools/tpm2_load \
+    tools/tpm2_loadexternal \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -73,7 +74,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_loadexternal \
 #    tools/tpm2_makecredential \
 #    tools/tpm2_nvdefine \
 #    tools/tpm2_nvlist \

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ bin_PROGRAMS = \
     tools/tpm2_makecredential \
     tools/tpm2_nvdefine \
     tools/tpm2_nvlist \
+    tools/tpm2_nvread \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -77,7 +78,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvread \
 #    tools/tpm2_nvreadlock \
 #    tools/tpm2_nvrelease \
 #    tools/tpm2_nvwrite \

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvlist \
     tools/tpm2_nvread \
     tools/tpm2_nvreadlock \
+    tools/tpm2_nvrelease \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -79,7 +80,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvrelease \
 #    tools/tpm2_nvwrite \
 #    tools/tpm2_pcrevent \
 #    tools/tpm2_pcrextend \

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvdefine \
     tools/tpm2_nvlist \
     tools/tpm2_nvread \
+    tools/tpm2_nvreadlock \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -78,7 +79,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvreadlock \
 #    tools/tpm2_nvrelease \
 #    tools/tpm2_nvwrite \
 #    tools/tpm2_pcrevent \

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ bin_PROGRAMS = \
     tools/tpm2_loadexternal \
     tools/tpm2_makecredential \
     tools/tpm2_nvdefine \
+    tools/tpm2_nvlist \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -76,7 +77,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvlist \
 #    tools/tpm2_nvread \
 #    tools/tpm2_nvreadlock \
 #    tools/tpm2_nvrelease \

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ bin_PROGRAMS = \
     tools/tpm2_load \
     tools/tpm2_loadexternal \
     tools/tpm2_makecredential \
+    tools/tpm2_nvdefine \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -75,7 +76,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvdefine \
 #    tools/tpm2_nvlist \
 #    tools/tpm2_nvread \
 #    tools/tpm2_nvreadlock \

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ bin_PROGRAMS = \
     tools/tpm2_getrandom \
     tools/tpm2_hmac \
     tools/tpm2_listpersistent \
+    tools/tpm2_load \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -72,7 +73,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_load \
 #    tools/tpm2_loadexternal \
 #    tools/tpm2_makecredential \
 #    tools/tpm2_nvdefine \

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ bin_PROGRAMS = \
     tools/tpm2_getpubek \
     tools/tpm2_getrandom \
     tools/tpm2_hmac \
+    tools/tpm2_listpersistent \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -71,7 +72,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_listpersistent \
 #    tools/tpm2_load \
 #    tools/tpm2_loadexternal \
 #    tools/tpm2_makecredential \

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ bin_PROGRAMS = \
     tools/tpm2_listpersistent \
     tools/tpm2_load \
     tools/tpm2_loadexternal \
+    tools/tpm2_makecredential \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -74,7 +75,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_makecredential \
 #    tools/tpm2_nvdefine \
 #    tools/tpm2_nvlist \
 #    tools/tpm2_nvread \

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvread \
     tools/tpm2_nvreadlock \
     tools/tpm2_nvrelease \
+    tools/tpm2_nvwrite \
     tools/tpm2_send_command \
     tools/tpm2_sign \
     tools/tpm2_startup \
@@ -80,7 +81,6 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 # NEED TO PORT
-#    tools/tpm2_nvwrite \
 #    tools/tpm2_pcrevent \
 #    tools/tpm2_pcrextend \
 #    tools/tpm2_pcrlist \

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -97,7 +97,7 @@ tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
     }
 
     opts->short_opts = strdup(short_opts);
-    if (!opts) {
+    if (!opts->short_opts) {
         LOG_ERR("oom");
         free(opts);
         return NULL;

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -34,9 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <limits.h>
 #include <ctype.h>
-#include <getopt.h>
 
 #include <sapi/tpm20.h>
 
@@ -77,17 +75,9 @@ int readPublic(TSS2_SYS_CONTEXT *sapi_context,
     return 0;
 }
 
-int
-execute_tool (int              argc,
-              char             *argv[],
-              char             *envp[],
-              common_opts_t    *opts,
-              TSS2_SYS_CONTEXT *sapi_context)
-{
-    (void) opts;
-    (void) envp;
-    (void) argc;
-    (void) argv;
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
 
     TPMI_YES_NO moreData;
     TPMS_CAPABILITY_DATA capabilityData;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -36,7 +36,6 @@
 #include <string.h>
 #include <limits.h>
 #include <ctype.h>
-#include <getopt.h>
 #include <stdbool.h>
 
 #include <sapi/tpm20.h>
@@ -49,20 +48,36 @@
 #include "tpm2_tool.h"
 
 TPM_HANDLE handle2048rsa;
-TPMS_AUTH_COMMAND sessionData = {
+
+typedef struct tpm_load_ctx tpm_load_ctx;
+struct tpm_load_ctx {
+    TPMS_AUTH_COMMAND session_data;
+    TPMI_DH_OBJECT parent_handle;
+    TPM2B_PUBLIC  in_public;
+    TPM2B_PRIVATE in_private;
+    char *out_file;
+    char *context_file;
+    char *context_parent_file;
+    struct {
+        UINT8 H : 1;
+        UINT8 u : 1;
+        UINT8 r : 1;
+        UINT8 c : 1;
+        UINT8 C : 1;
+        UINT8 n : 1;
+    } flags;
+};
+
+static tpm_load_ctx ctx = {
+    .session_data = {
         .sessionHandle = TPM_RS_PW,
         .nonce = TPM2B_EMPTY_INIT,
         .hmac = TPM2B_EMPTY_INIT,
-        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0),
+        .sessionAttributes = SESSION_ATTRIBUTES_INIT(0)
+    }
 };
 
-int
-load (TSS2_SYS_CONTEXT *sapi_context,
-      TPMI_DH_OBJECT    parentHandle,
-      TPM2B_PUBLIC     *inPublic,
-      TPM2B_PRIVATE    *inPrivate,
-      const char       *outFileName)
-{
+int load (TSS2_SYS_CONTEXT *sapi_context) {
     UINT32 rval;
     TPMS_AUTH_RESPONSE sessionDataOut;
     TSS2_SYS_CMD_AUTHS sessionsData;
@@ -72,7 +87,7 @@ load (TSS2_SYS_CONTEXT *sapi_context,
 
     TPM2B_NAME nameExt = TPM2B_TYPE_INIT(TPM2B_NAME, name);
 
-    sessionDataArray[0] = &sessionData;
+    sessionDataArray[0] = &ctx.session_data;
     sessionDataOutArray[0] = &sessionDataOut;
 
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
@@ -81,14 +96,14 @@ load (TSS2_SYS_CONTEXT *sapi_context,
     sessionsDataOut.rspAuthsCount = 1;
     sessionsData.cmdAuthsCount = 1;
 
-    rval = Tss2_Sys_Load (sapi_context,
-                          parentHandle,
-                          &sessionsData,
-                          inPrivate,
-                          inPublic,
-                          &handle2048rsa,
-                          &nameExt,
-                          &sessionsDataOut);
+    rval = Tss2_Sys_Load(sapi_context,
+                         ctx.parent_handle,
+                         &sessionsData,
+                         &ctx.in_private,
+                         &ctx.in_public,
+                         &handle2048rsa,
+                         &nameExt,
+                         &sessionsDataOut);
     if(rval != TPM_RC_SUCCESS)
     {
         LOG_ERR("\nLoad Object Failed ! ErrorCode: 0x%0x\n",rval);
@@ -97,39 +112,81 @@ load (TSS2_SYS_CONTEXT *sapi_context,
     tpm2_tool_output("\nLoad succ.\nLoadedHandle: 0x%08x\n\n",handle2048rsa);
 
     /* TODO fix serialization */
-    if(!files_save_bytes_to_file(outFileName, (UINT8 *)&nameExt, sizeof(nameExt)))
+    if(!files_save_bytes_to_file(ctx.out_file, (UINT8 *)&nameExt, sizeof(nameExt)))
         return -2;
 
     return 0;
 }
 
-int
-execute_tool (int              argc,
-              char             *argv[],
-              char             *envp[],
-              common_opts_t    *opts,
-              TSS2_SYS_CONTEXT *sapi_context)
-{
-    (void) envp;
-    (void) opts;
+static bool on_option(char key, char *value) {
 
-    TPMI_DH_OBJECT parentHandle;
-    TPM2B_PUBLIC  inPublic;
-    TPM2B_PRIVATE inPrivate;
+    bool res;
     UINT16 size;
-    char *outFilePath = NULL;
-    char *contextFile = NULL;
-    char *contextParentFilePath = NULL;
 
-    memset(&inPublic,0,sizeof(TPM2B_PUBLIC));
-    memset(&inPrivate,0,sizeof(TPM2B_SENSITIVE));
+    switch(key) {
+    case 'H':
+        if (!tpm2_util_string_to_uint32(optarg, &ctx.parent_handle)) {
+                return false;
+        }
+        ctx.flags.H = 1;
+        break;
+    case 'P':
+        res = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!res) {
+            LOG_ERR("Invalid parent key password, got\"%s\"", value);
+            return false;
+        }
+        break;
+    case 'u':
+        size = sizeof(ctx.in_public);
+        if(!files_load_bytes_from_path(optarg, (UINT8 *)&ctx.in_public, &size)) {
+            return false;;
+        }
+        ctx.flags.u = 1;
+        break;
+    case 'r':
+        size = sizeof(ctx.in_private);
+        if(!files_load_bytes_from_path(value, (UINT8 *)&ctx.in_private, &size)) {
+            return false;
+        }
+        ctx.flags.r = 1;
+        break;
+    case 'n':
+        ctx.out_file = value;
+        if(files_does_file_exist(ctx.out_file)) {
+            return false;
+        }
+        ctx.flags.n = 1;
+        break;
+    case 'c':
+        ctx.context_parent_file = value;
+        if(ctx.context_parent_file == NULL || ctx.context_parent_file[0] == '\0') {
+                return false;
+        }
+        ctx.flags.c = 1;
+        break;
+    case 'C':
+        ctx.context_file = value;
+        if(ctx.context_file == NULL || ctx.context_file[0] == '\0') {
+            return false;
+        }
+        ctx.flags.C = 1;
+        break;
+    case 'S':
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
+            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+        break;
+    }
 
-    setbuf(stdout, NULL);
-    setvbuf (stdout, NULL, _IONBF, BUFSIZ);
+    return true;
+}
 
-    int opt = -1;
-    const char *optstring = "H:P:u:r:n:C:c:S:";
-    static struct option long_options[] = {
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
       {"parent",1,NULL,'H'},
       {"pwdp",1,NULL,'P'},
       {"pubfile",1,NULL,'u'},
@@ -141,126 +198,49 @@ execute_tool (int              argc,
       {0,0,0,0}
     };
 
+    setbuf(stdout, NULL);
+    setvbuf (stdout, NULL, _IONBF, BUFSIZ);
+
+    *opts = tpm2_options_new("H:P:u:r:n:C:c:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
     int returnVal = 0;
     int flagCnt = 0;
-    int H_flag = 0,
-        u_flag = 0,
-        r_flag = 0,
-        c_flag = 0,
-        C_flag = 0,
-        n_flag = 0;
 
-    while((opt = getopt_long(argc,argv,optstring,long_options,NULL)) != -1)
-    {
-        switch(opt)
-        {
-        case 'H':
-            if (!tpm2_util_string_to_uint32(optarg, &parentHandle))
-            {
-                return 1;
-            }
-            tpm2_tool_output("\nparentHandle: 0x%x\n\n",parentHandle);
-            H_flag = 1;
-            break;
-        case 'P': {
-            bool res = tpm2_password_util_from_optarg(optarg, &sessionData.hmac);
-            if (!res) {
-                LOG_ERR("Invalid parent key password, got\"%s\"", optarg);
-                return 1;
-            }
-        } break;
+    flagCnt = ctx.flags.H + ctx.flags.u + ctx.flags.r + ctx.flags.n + ctx.flags.c;
 
-        case 'u':
-            size = sizeof(inPublic);
-            if(!files_load_bytes_from_path(optarg, (UINT8 *)&inPublic, &size))
-            {
-                return 1;
-            }
-            u_flag = 1;
-            break;
-        case 'r':
-            size = sizeof(inPrivate);
-            if(!files_load_bytes_from_path(optarg, (UINT8 *)&inPrivate, &size))
-            {
-                return 1;
-            }
-            r_flag = 1;
-            break;
-        case 'n':
-            outFilePath = optarg;
-            if(files_does_file_exist(outFilePath))
-            {
-                return 1;
-            }
-            n_flag = 1;
-            break;
-        case 'c':
-            contextParentFilePath = optarg;
-            if(contextParentFilePath == NULL || contextParentFilePath[0] == '\0')
-            {
-                return 1;
-            }
-            tpm2_tool_output("contextParentFile = %s\n", contextParentFilePath);
-            c_flag = 1;
-            break;
-        case 'C':
-            contextFile = optarg;
-            if(contextFile == NULL || contextFile[0] == '\0')
-            {
-                return 1;
-            }
-            tpm2_tool_output("contextFile = %s\n", contextFile);
-            C_flag = 1;
-            break;
-        case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &sessionData.sessionHandle)) {
-                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                         optarg);
-                 return 1;
-             }
-             break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return 1;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return 1;
-	default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return 1;
-        }
-    };
+    if(flagCnt == 4 && (ctx.flags.H == 1 || ctx.flags.c == 1) &&
+       ctx.flags.u == 1 && ctx.flags.r == 1 && ctx.flags.n == 1) {
 
-    flagCnt = H_flag + u_flag +r_flag + n_flag + c_flag;
-    if(flagCnt == 4 && (H_flag == 1 || c_flag == 1) && u_flag == 1 && r_flag == 1 && n_flag == 1)
-    {
-        if(c_flag) {
-            returnVal = files_load_tpm_context_from_file (sapi_context,
-                                                &parentHandle,
-                                                contextParentFilePath) != true;
+        if(ctx.flags.c) {
+            returnVal = files_load_tpm_context_from_file(sapi_context,
+                                               &ctx.parent_handle,
+                                               ctx.context_parent_file) != true;
             if (returnVal) {
                 return 1;
             }
         }
 
-        returnVal = load (sapi_context, parentHandle, &inPublic, &inPrivate,
-                          outFilePath);
+        returnVal = load (sapi_context);
         if (returnVal) {
             return 1;
         }
-        if (C_flag) {
+        if (ctx.flags.C) {
             returnVal = files_save_tpm_context_to_file (sapi_context,
                                               handle2048rsa,
-                                              contextFile) != true;
+                                              ctx.context_file) != true;
             if (returnVal) {
                 return 1;
             }
         }
 
-    }
-    else
-    {
-        showArgMismatch(argv[0]);
+    } else {
         return 1;
     }
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <getopt.h>
 #include <sapi/tpm20.h>
 
 #include "tpm2_options.h"
@@ -53,8 +52,13 @@ struct tpm_loadexternal_ctx {
     TPM2B_SENSITIVE private_key;
     bool has_private_key;
     bool save_to_context_file;
-    TSS2_SYS_CONTEXT *sapi_context;
+    struct {
+        UINT8 H : 1;
+        UINT8 u : 1;
+    } flags;
 };
+
+static tpm_loadexternal_ctx ctx;
 
 static bool get_hierarchy_value(const char *argument_opt,
         TPMI_RH_HIERARCHY *hierarchy_value) {
@@ -87,7 +91,7 @@ static bool get_hierarchy_value(const char *argument_opt,
     return true;
 }
 
-static bool load_external(tpm_loadexternal_ctx *ctx) {
+static bool load_external(TSS2_SYS_CONTEXT *sapi_context) {
 
     TSS2_SYS_RSP_AUTHS sessionsDataOut;
     TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
@@ -97,9 +101,9 @@ static bool load_external(tpm_loadexternal_ctx *ctx) {
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
     sessionsDataOut.rspAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_LoadExternal(ctx->sapi_context, 0,
-            ctx->has_private_key ? &ctx->private_key : NULL, &ctx->public_key,
-            ctx->hierarchy_value, &ctx->rsa2048_handle, &nameExt,
+    TPM_RC rval = Tss2_Sys_LoadExternal(sapi_context, 0,
+            ctx.has_private_key ? &ctx.private_key : NULL, &ctx.public_key,
+            ctx.hierarchy_value, &ctx.rsa2048_handle, &nameExt,
             &sessionsDataOut);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("LoadExternal Failed ! ErrorCode: 0x%0x", rval);
@@ -109,10 +113,47 @@ static bool load_external(tpm_loadexternal_ctx *ctx) {
     return true;
 }
 
-static bool init(int argc, char *argv[], tpm_loadexternal_ctx *ctx) {
+static bool on_option(char key, char *value) {
 
-    const char *optstring = "H:u:r:C:";
-    static struct option long_options[] = {
+    bool result;
+    UINT16 size;
+
+    switch(key) {
+    case 'H':
+        result = get_hierarchy_value(value, &ctx.hierarchy_value);
+        if (!result) {
+            return false;
+        }
+        ctx.flags.H = 1;
+    break;
+    case 'u':
+        size = sizeof(ctx.public_key);
+        result = files_load_bytes_from_path(value, (UINT8 *)&ctx.public_key, &size);
+        if (!result) {
+            return false;
+        }
+        ctx.flags.u = 1;
+        break;
+    case 'r':
+        size = sizeof(ctx.private_key);
+        result = files_load_bytes_from_path(value, (UINT8 *)&ctx.private_key, &size);
+        if (!result) {
+            return false;
+        }
+        ctx.has_private_key = true;
+        break;
+    case 'C':
+        ctx.context_file_path = value;
+        ctx.save_to_context_file = true;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
       { "Hierachy", required_argument, NULL, 'H'},
       { "pubfile",  required_argument, NULL, 'u'},
       { "privfile", required_argument, NULL, 'r'},
@@ -120,98 +161,27 @@ static bool init(int argc, char *argv[], tpm_loadexternal_ctx *ctx) {
       { NULL,       no_argument,       NULL, '\0' }
     };
 
-    union {
-        struct {
-            UINT8 H : 1;
-            UINT8 u : 1;
-            UINT8 unused : 6;
-        };
-        UINT8 all;
-    } flags = { .all = 0 };
+    *opts = tpm2_options_new("H:u:r:C:", ARRAY_LEN(topts), topts, on_option, NULL);
 
-    if(argc == 1) {
-        showArgMismatch(argv[0]);
-        return false;
-    }
+    return *opts != NULL;
+}
 
-    int opt = -1;
-    while((opt = getopt_long(argc,argv,optstring,long_options,NULL)) != -1)
-    {
-        switch(opt)
-        {
-        case 'H': {
-            bool result = get_hierarchy_value(optarg, &ctx->hierarchy_value);
-            if (!result) {
-                return false;
-            }
-        }
-        flags.H = 1;
-        break;
-        case 'u': {
-            UINT16 size = sizeof(ctx->public_key);
-            bool result = files_load_bytes_from_path(optarg, (UINT8 *)&ctx->public_key, &size);
-            if (!result) {
-                return false;
-            }
-            flags.u = 1;
-        } break;
-        case 'r': {
-            UINT16 size = sizeof(ctx->private_key);
-            bool result = files_load_bytes_from_path(optarg, (UINT8 *)&ctx->private_key, &size);
-            if (!result) {
-                return false;
-            }
-            ctx->has_private_key = true;
-        } break;
-        case 'C':
-            ctx->context_file_path = optarg;
-            ctx->save_to_context_file = true;
-            break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    if (!(flags.H && flags.u)) {
+    UNUSED(flags);
+
+    if (!(ctx.flags.H && ctx.flags.u)) {
         LOG_ERR("Expected H and u options");
         return false;
     }
 
-    return true;
-}
-
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
-
-    /* opts and envp are unused, avoid compiler warning */
-    (void)opts;
-    (void) envp;
-
-    tpm_loadexternal_ctx ctx = {
-            .has_private_key = false,
-            .save_to_context_file = false,
-            .sapi_context = sapi_context
-    };
-
-    bool result = init(argc, argv, &ctx);
-    if(!result) {
-        return 1;
-    }
-
-    result = load_external(&ctx);
+    bool result = load_external(sapi_context);
     if (!result) {
         return 1;
     }
 
     if(ctx.save_to_context_file) {
-            return files_save_tpm_context_to_file(ctx.sapi_context, ctx.rsa2048_handle,
+            return files_save_tpm_context_to_file(sapi_context, ctx.rsa2048_handle,
                     ctx.context_file_path) != true;
     }
 

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -35,7 +35,6 @@
 #include <string.h>
 #include <limits.h>
 #include <ctype.h>
-#include <getopt.h>
 
 #include <sapi/tpm20.h>
 
@@ -45,14 +44,6 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
-#define tpm_makecred_ctx_empty_init { \
-		.rsa2048_handle = 0, \
-		.object_name = TPM2B_EMPTY_INIT, \
-		.out_file_path = NULL, \
-        .public = TPM2B_EMPTY_INIT, \
-        .credential = TPM2B_EMPTY_INIT, \
-    }
-
 typedef struct tpm_makecred_ctx tpm_makecred_ctx;
 struct tpm_makecred_ctx {
     TPM_HANDLE rsa2048_handle;
@@ -60,6 +51,18 @@ struct tpm_makecred_ctx {
     char *out_file_path;
     TPM2B_PUBLIC public;
     TPM2B_DIGEST credential;
+    struct {
+        UINT8 e : 1;
+        UINT8 s : 1;
+        UINT8 n : 1;
+        UINT8 o : 1;
+    } flags;
+};
+
+static tpm_makecred_ctx ctx = {
+    .object_name = TPM2B_EMPTY_INIT,
+    .public = TPM2B_EMPTY_INIT,
+    .credential = TPM2B_EMPTY_INIT,
 };
 
 static bool write_cred_and_secret(const char *path, TPM2B_ID_OBJECT *cred,
@@ -95,7 +98,7 @@ out:
     return result;
 }
 
-static bool make_credential_and_save(TSS2_SYS_CONTEXT *sapi_context, tpm_makecred_ctx *ctx)
+static bool make_credential_and_save(TSS2_SYS_CONTEXT *sapi_context)
 {
     TPMS_AUTH_RESPONSE session_data_out;
     TSS2_SYS_RSP_AUTHS sessions_data_out;
@@ -111,34 +114,73 @@ static bool make_credential_and_save(TSS2_SYS_CONTEXT *sapi_context, tpm_makecre
     sessions_data_out.rspAuths = &session_data_out_array[0];
     sessions_data_out.rspAuthsCount = 1;
 
-    UINT32 rval = Tss2_Sys_LoadExternal(sapi_context, 0, NULL, &ctx->public,
-            TPM_RH_NULL, &ctx->rsa2048_handle, &name_ext, &sessions_data_out);
+    UINT32 rval = Tss2_Sys_LoadExternal(sapi_context, 0, NULL, &ctx.public,
+            TPM_RH_NULL, &ctx.rsa2048_handle, &name_ext, &sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("LoadExternal failed. TPM Error:0x%x", rval);
         return false;
     }
 
-    rval = Tss2_Sys_MakeCredential(sapi_context, ctx->rsa2048_handle, 0,
-            &ctx->credential, &ctx->object_name, &cred_blob, &secret,
+    rval = Tss2_Sys_MakeCredential(sapi_context, ctx.rsa2048_handle, 0,
+            &ctx.credential, &ctx.object_name, &cred_blob, &secret,
             &sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("MakeCredential failed. TPM Error:0x%x", rval);
         return false;
     }
 
-    rval = Tss2_Sys_FlushContext(sapi_context, ctx->rsa2048_handle);
+    rval = Tss2_Sys_FlushContext(sapi_context, ctx.rsa2048_handle);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Flush loaded key failed. TPM Error:0x%x", rval);
         return false;
     }
 
-    return write_cred_and_secret(ctx->out_file_path, &cred_blob, &secret);
+    return write_cred_and_secret(ctx.out_file_path, &cred_blob, &secret);
 }
 
-static bool init(int argc, char *argv[], tpm_makecred_ctx *ctx) {
+static bool on_option(char key, char *value) {
 
-    static const char *optstring = "e:s:n:o:";
-    static const struct option long_options[] = {
+    UINT16 size;
+
+    switch (key) {
+    case 'e':
+        size = sizeof(ctx.public);
+        if (!files_load_bytes_from_path(value, (UINT8 *) &ctx.public, &size)) {
+            return false;
+        }
+        ctx.flags.e = 1;
+        break;
+    case 's':
+        ctx.credential.t.size = BUFFER_SIZE(TPM2B_DIGEST, buffer);
+        if (!files_load_bytes_from_path(value, ctx.credential.t.buffer,
+                                        &ctx.credential.t.size)) {
+            return false;
+        }
+        ctx.flags.s = 1;
+        break;
+    case 'n':
+        ctx.object_name.t.size = BUFFER_SIZE(TPM2B_NAME, name);
+        if (tpm2_util_hex_to_byte_structure(value, &ctx.object_name.t.size,
+                                            ctx.object_name.t.name) != 0) {
+            return false;
+        }
+        ctx.flags.n = 1;
+        break;
+    case 'o':
+        ctx.out_file_path = optarg;
+        if (files_does_file_exist(ctx.out_file_path)) {
+            return false;
+        }
+            ctx.flags.o = 1;
+            break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
       {"encKey"  ,required_argument, NULL, 'e'},
       {"sec"     ,required_argument, NULL, 's'},
       {"name"    ,required_argument, NULL, 'n'},
@@ -146,92 +188,19 @@ static bool init(int argc, char *argv[], tpm_makecred_ctx *ctx) {
       {NULL      ,no_argument      , NULL, '\0'}
     };
 
-    if (argc == 1) {
-        showArgMismatch(argv[0]);
-        return false;
-    }
+    *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option, NULL);
 
-    union {
-        struct {
-            UINT8 e : 1;
-            UINT8 s : 1;
-            UINT8 n : 1;
-            UINT8 o : 1;
-            UINT8 unused : 4;
-        };
-        UINT8 all;
-    } flags = {
-      .all = 0,
-    };
-
-    int opt = -1;
-    while ((opt = getopt_long(argc, argv, optstring, long_options, NULL))
-            != -1) {
-        switch (opt) {
-        case 'e': {
-            UINT16 size = sizeof(ctx->public);
-            if (!files_load_bytes_from_path(optarg, (UINT8 *) &ctx->public, &size)) {
-                return false;
-            }
-            flags.e = 1;
-            break;
-        }
-        case 's':
-            ctx->credential.t.size = BUFFER_SIZE(TPM2B_DIGEST, buffer);
-            if (!files_load_bytes_from_path(optarg, ctx->credential.t.buffer,
-                    &ctx->credential.t.size)) {
-                return false;
-            }
-            flags.s = 1;
-            break;
-        case 'n':
-            ctx->object_name.t.size = BUFFER_SIZE(TPM2B_NAME, name);
-            if (tpm2_util_hex_to_byte_structure(optarg, &ctx->object_name.t.size,
-                    ctx->object_name.t.name) != 0) {
-                return false;
-            }
-            flags.n = 1;
-            break;
-        case 'o':
-            ctx->out_file_path = optarg;
-            if (files_does_file_exist(ctx->out_file_path)) {
-                return false;
-            }
-            flags.o = 1;
-            break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
-
-    if (!flags.e || !flags.n || !flags.o || !flags.s) {
-        showArgMismatch(argv[0]);
-        return false;
-    }
-
-    return true;
+    return *opts != NULL;
 }
 
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    /* opts is unused, avoid compiler warning */
-    (void) opts;
-    (void) envp;
+    UNUSED(flags);
 
-    tpm_makecred_ctx ctx = tpm_makecred_ctx_empty_init;
-    bool result = init(argc, argv, &ctx);
-    if (!result) {
-        LOG_ERR("Initialization failed");
-        return 1;
+    if (!ctx.flags.e || !ctx.flags.n || !ctx.flags.o || !ctx.flags.s) {
+        LOG_ERR("Expected options e, n, o and s");
+        return false;
     }
 
-    return make_credential_and_save(sapi_context, &ctx) != true;
+    return make_credential_and_save(sapi_context) != true;
 }

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -97,13 +97,9 @@ static bool nv_list(TSS2_SYS_CONTEXT *sapi_context) {
     return true;
 }
 
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    (void) argc;
-    (void) argv;
-    (void) envp;
-    (void) opts;
+    UNUSED(flags);
 
     return !nv_list(sapi_context);
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -34,8 +34,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <getopt.h>
-
 #include <sapi/tpm20.h>
 
 #include "tpm2_options.h"
@@ -52,7 +50,12 @@ struct tpm_nvread_ctx {
     UINT32 size_to_read;
     UINT32 offset;
     TPMS_AUTH_COMMAND session_data;
-    TSS2_SYS_CONTEXT *sapi_context;
+};
+
+static tpm_nvread_ctx ctx = {
+    .auth_handle = TPM_RH_PLATFORM,
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+
 };
 
 static void hexdump(void *ptr, unsigned buflen) {
@@ -79,7 +82,7 @@ static void hexdump(void *ptr, unsigned buflen) {
     }
 }
 
-static bool nv_read(tpm_nvread_ctx *ctx) {
+static bool nv_read(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMS_AUTH_RESPONSE session_data_out;
     TSS2_SYS_CMD_AUTHS sessions_data;
@@ -90,7 +93,7 @@ static bool nv_read(tpm_nvread_ctx *ctx) {
     TPMS_AUTH_COMMAND *session_data_array[1];
     TPMS_AUTH_RESPONSE *session_data_out_array[1];
 
-    session_data_array[0] = &ctx->session_data;
+    session_data_array[0] = &ctx.session_data;
     session_data_out_array[0] = &session_data_out;
 
     sessions_data_out.rspAuths = &session_data_out_array[0];
@@ -100,33 +103,33 @@ static bool nv_read(tpm_nvread_ctx *ctx) {
     sessions_data.cmdAuthsCount = 1;
 
     TPM2B_NV_PUBLIC nv_public = TPM2B_EMPTY_INIT;
-    TPM_RC rval = tpm2_util_nv_read_public(ctx->sapi_context, ctx->nv_index, &nv_public);
+    TPM_RC rval = tpm2_util_nv_read_public(sapi_context, ctx.nv_index, &nv_public);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to read NVRAM public area at index 0x%x (%d). Error:0x%x",
-                ctx->nv_index, ctx->nv_index, rval);
+                ctx.nv_index, ctx.nv_index, rval);
         return false;
     }
 
     UINT16 data_size = nv_public.t.nvPublic.dataSize;
 
     /* if no size was specified, assume the whole object */
-    if (ctx->size_to_read == 0) {
-        ctx->size_to_read = data_size;
+    if (ctx.size_to_read == 0) {
+        ctx.size_to_read = data_size;
     }
 
-    if (ctx->offset > data_size) {
+    if (ctx.offset > data_size) {
         LOG_ERR(
             "Requested offset to read from is greater than size. offset=%u"
-            ", size=%u", ctx->offset, data_size);
+            ", size=%u", ctx.offset, data_size);
         return false;
     }
 
-    if (ctx->offset + ctx->size_to_read > data_size) {
+    if (ctx.offset + ctx.size_to_read > data_size) {
         LOG_WARN(
             "Requested to read more bytes than available from offset,"
             " truncating read! offset=%u, request-read-size=%u"
-            " actual-data-size=%u", ctx->offset, ctx->size_to_read, data_size);
-        ctx->size_to_read = data_size - ctx->offset;
+            " actual-data-size=%u", ctx.offset, ctx.size_to_read, data_size);
+        ctx.size_to_read = data_size - ctx.offset;
         return false;
     }
 
@@ -139,21 +142,21 @@ static bool nv_read(tpm_nvread_ctx *ctx) {
 
     bool result = false;
     UINT16 data_offest = 0;
-    while (ctx->size_to_read) {
+    while (ctx.size_to_read) {
 
-        UINT16 bytes_to_read = ctx->size_to_read > MAX_NV_BUFFER_SIZE ?
-                        MAX_NV_BUFFER_SIZE : ctx->size_to_read;
+        UINT16 bytes_to_read = ctx.size_to_read > MAX_NV_BUFFER_SIZE ?
+                        MAX_NV_BUFFER_SIZE : ctx.size_to_read;
 
-        rval = Tss2_Sys_NV_Read(ctx->sapi_context, ctx->auth_handle, ctx->nv_index,
-                &sessions_data, bytes_to_read, ctx->offset, &nv_data, &sessions_data_out);
+        rval = Tss2_Sys_NV_Read(sapi_context, ctx.auth_handle, ctx.nv_index,
+                &sessions_data, bytes_to_read, ctx.offset, &nv_data, &sessions_data_out);
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("Failed to read NVRAM area at index 0x%x (%d). Error:0x%x",
-                    ctx->nv_index, ctx->nv_index, rval);
+                    ctx.nv_index, ctx.nv_index, rval);
             goto out;
         }
 
-        ctx->size_to_read -= nv_data.t.size;
-        ctx->offset += nv_data.t.size;
+        ctx.size_to_read -= nv_data.t.size;
+        ctx.offset += nv_data.t.size;
 
         memcpy(data_buffer, nv_data.t.buffer, data_offest);
         data_offest += nv_data.t.size;
@@ -167,9 +170,74 @@ out:
     return result;
 }
 
-static bool init(int argc, char *argv[], tpm_nvread_ctx *ctx) {
+static bool on_option(char key, char *value) {
 
-    struct option long_options[] = {
+    bool result;
+
+    switch (key) {
+    case 'x':
+        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
+        if (!result) {
+            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
+                    optarg);
+            return false;
+        }
+
+        if (ctx.nv_index == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+        }
+        break;
+    case 'a':
+        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        if (!result) {
+            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
+                    optarg);
+            return false;
+        }
+
+        if (ctx.auth_handle == 0) {
+            LOG_ERR("Auth handle cannot be 0");
+            return false;
+        }
+        break;
+    case 'P':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid handle password, got\"%s\"", optarg);
+            return false;
+        }
+        break;
+    case 's':
+        result = tpm2_util_string_to_uint32(value, &ctx.size_to_read);
+        if (!result) {
+            LOG_ERR("Could not convert size to number, got: \"%s\"",
+                    optarg);
+            return false;
+        }
+        break;
+    case 'o':
+        result = tpm2_util_string_to_uint32(value, &ctx.offset);
+        if (!result) {
+            LOG_ERR("Could not convert offset to number, got: \"%s\"",
+                    optarg);
+            return false;
+        }
+        break;
+    case 'S':
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
+            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                    optarg);
+            return false;
+        }
+        break;
+    }
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
         { "authHandle"  , required_argument, NULL, 'a' },
         { "size"        , required_argument, NULL, 's' },
@@ -179,101 +247,14 @@ static bool init(int argc, char *argv[], tpm_nvread_ctx *ctx) {
         { NULL          , no_argument,       NULL, 0   },
     };
 
-    int opt;
-    bool result;
-    while ((opt = getopt_long(argc, argv, "x:a:s:o:P:S:", long_options, NULL))
-            != -1) {
-        switch (opt) {
-        case 'x':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->nv_index);
-            if (!result) {
-                LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
+    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
 
-            if (ctx->nv_index == 0) {
-                LOG_ERR("NV Index cannot be 0");
-                return false;
-            }
-
-            break;
-        case 'a':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->auth_handle);
-            if (!result) {
-                LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-
-            if (ctx->auth_handle == 0) {
-                LOG_ERR("Auth handle cannot be 0");
-                return false;
-            }
-            break;
-        case 'P':
-            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
-            if (!result) {
-                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
-                return false;
-            }
-            break;
-        case 's':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->size_to_read);
-            if (!result) {
-                LOG_ERR("Could not convert size to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-            break;
-        case 'o':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->offset);
-            if (!result) {
-                LOG_ERR("Could not convert offset to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-            break;
-        case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
-                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                         optarg);
-                 return false;
-             }
-             break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
-    return true;
+    return *opts != NULL;
 }
 
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    (void)opts;
-    (void)envp;
+    UNUSED(flags);
 
-    tpm_nvread_ctx ctx = {
-            .nv_index = 0,
-            .auth_handle = TPM_RH_PLATFORM,
-            .size_to_read = 0,
-            .offset = 0,
-            .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
-            .sapi_context = sapi_context,
-    };
-
-    bool result = init(argc, argv, &ctx);
-    if (!result) {
-        return 1;
-    }
-
-    return nv_read(&ctx) != true;
+    return nv_read(sapi_context) != true;
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -35,7 +35,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <getopt.h>
 
 #include <sapi/tpm20.h>
 
@@ -55,7 +54,13 @@ struct tpm_nvreadlock_ctx {
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
-static bool nv_readlock(tpm_nvreadlock_ctx *ctx) {
+static tpm_nvreadlock_ctx ctx = {
+    .auth_handle = TPM_RH_PLATFORM,
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+
+};
+
+static bool nv_readlock(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMS_AUTH_RESPONSE session_data_out;
     TSS2_SYS_CMD_AUTHS sessions_data;
@@ -64,7 +69,7 @@ static bool nv_readlock(tpm_nvreadlock_ctx *ctx) {
     TPMS_AUTH_COMMAND *session_data_array[1];
     TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
 
-    session_data_array[0] = &ctx->session_data;
+    session_data_array[0] = &ctx.session_data;
     sessionDataOutArray[0] = &session_data_out;
 
     sessions_data_out.rspAuths = &sessionDataOutArray[0];
@@ -73,22 +78,70 @@ static bool nv_readlock(tpm_nvreadlock_ctx *ctx) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_NV_ReadLock(ctx->sapi_context, ctx->auth_handle, ctx->nv_index,
+    TPM_RC rval = Tss2_Sys_NV_ReadLock(sapi_context, ctx.auth_handle, ctx.nv_index,
             &sessions_data, &sessions_data_out);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to lock NVRAM area at index 0x%x (%d).Error:0x%x",
-                ctx->nv_index, ctx->nv_index, rval);
+                ctx.nv_index, ctx.nv_index, rval);
         return false;
     }
 
     return true;
 }
 
-#define ARG_CNT(optional) ((int)(2 * (sizeof(long_options)/sizeof(long_options[0]) - optional - 1)))
+static bool on_option(char key, char *value) {
 
-static bool init(int argc, char *argv[], tpm_nvreadlock_ctx *ctx) {
+    bool result;
 
-    struct option long_options[] = {
+    switch (key) {
+    case 'x':
+        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
+        if (!result) {
+            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.nv_index == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+        }
+        break;
+    case 'a':
+        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        if (!result) {
+            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.auth_handle == 0) {
+            LOG_ERR("Auth handle cannot be 0");
+            return false;
+        }
+        break;
+    case 'P':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid handle password, got\"%s\"", value);
+                return false;
+        }
+        break;
+    case 'S':
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
+            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
         { "authHandle"  , required_argument, NULL, 'a' },
         { "handlePasswd", required_argument, NULL, 'P' },
@@ -97,91 +150,14 @@ static bool init(int argc, char *argv[], tpm_nvreadlock_ctx *ctx) {
         { NULL          , no_argument,       NULL, 0   },
     };
 
-    /* subtract 1 from argc to disregard argv[0] */
-    if ((argc - 1) < ARG_CNT(1) || (argc - 1) > ARG_CNT(0)) {
-        showArgMismatch(argv[0]);
-        return false;
-    }
+    *opts = tpm2_options_new("x:a:P:Xp:d:S:hv", ARRAY_LEN(topts), topts, on_option, NULL);
 
-    int opt;
-    bool result;
-    while ((opt = getopt_long(argc, argv, "x:a:P:Xp:d:S:hv", long_options, NULL))
-            != -1) {
-        switch (opt) {
-        case 'x':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->nv_index);
-            if (!result) {
-                LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-
-            if (ctx->nv_index == 0) {
-                LOG_ERR("NV Index cannot be 0");
-                return false;
-            }
-            break;
-        case 'a':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->auth_handle);
-            if (!result) {
-                LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-
-            if (ctx->auth_handle == 0) {
-                LOG_ERR("Auth handle cannot be 0");
-                return false;
-            }
-            break;
-        case 'P':
-            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
-            if (!result) {
-                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
-                return false;
-            }
-            break;
-        case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
-                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                         optarg);
-                 return false;
-             }
-             break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
-
-    return true;
+    return *opts != NULL;
 }
 
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    (void)opts;
-    (void)envp;
+    UNUSED(flags);
 
-    tpm_nvreadlock_ctx ctx = {
-            .nv_index = 0,
-            .auth_handle = TPM_RH_PLATFORM,
-            .size_to_read = 0,
-            .offset = 0,
-            .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
-            .sapi_context = sapi_context
-    };
-
-    bool result = init(argc, argv, &ctx);
-    if (!result) {
-        return 1;
-    }
-
-    return nv_readlock(&ctx) != true;
+    return nv_readlock(sapi_context) != true;
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -33,7 +33,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <getopt.h>
 
 #include <sapi/tpm20.h>
 
@@ -48,35 +47,88 @@ struct tpm_nvrelease_ctx {
     UINT32 nv_index;
     UINT32 auth_handle;
     TPMS_AUTH_COMMAND session_data;
-    TSS2_SYS_CONTEXT *sapi_context;
 };
 
-static bool nv_space_release(tpm_nvrelease_ctx *ctx) {
+static tpm_nvrelease_ctx ctx = {
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+};
+
+static bool nv_space_release(TSS2_SYS_CONTEXT *sapi_context) {
 
     TSS2_SYS_CMD_AUTHS sessions_data;
     TPMS_AUTH_COMMAND *session_data_array[1];
 
-    session_data_array[0] = &ctx->session_data;
+    session_data_array[0] = &ctx.session_data;
     sessions_data.cmdAuths = &session_data_array[0];
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_NV_UndefineSpace(ctx->sapi_context, ctx->auth_handle,
-            ctx->nv_index, &sessions_data, 0);
+    TPM_RC rval = Tss2_Sys_NV_UndefineSpace(sapi_context, ctx.auth_handle,
+                                            ctx.nv_index, &sessions_data, 0);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to release NV area at index 0x%x (%d).Error:0x%x",
-                ctx->nv_index, ctx->nv_index, rval);
+                ctx.nv_index, ctx.nv_index, rval);
         return false;
     }
 
-    LOG_INFO("Success to release NV area at index 0x%x (%d).", ctx->nv_index,
-            ctx->nv_index);
+    LOG_INFO("Success to release NV area at index 0x%x (%d).", ctx.nv_index,
+            ctx.nv_index);
 
     return true;
 }
 
-static bool init(int argc, char* argv[], tpm_nvrelease_ctx *ctx) {
+static bool on_option(char key, char *value) {
 
-    struct option long_options[] = {
+    bool result;
+
+    switch (key) {
+    case 'x':
+        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
+        if (!result) {
+            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.nv_index == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+        }
+        break;
+    case 'a':
+        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        if (!result) {
+            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.auth_handle == 0) {
+            LOG_ERR("Auth handle cannot be 0");
+            return false;
+        }
+        break;
+    case 'S':
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
+            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+        break;
+    case 'P':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid handle password, got\"%s\"", value);
+            return false;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
         { "authHandle"  , required_argument, NULL, 'a' },
         { "handlePasswd", required_argument, NULL, 'P' },
@@ -84,84 +136,14 @@ static bool init(int argc, char* argv[], tpm_nvrelease_ctx *ctx) {
         { NULL          , no_argument,       NULL,  0  },
     };
 
-    int opt;
-    bool result;
-    while ((opt = getopt_long(argc, argv, "x:a:s:o:P:S:", long_options, NULL))
-            != -1) {
-        switch (opt) {
-        case 'x':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->nv_index);
-            if (!result) {
-                LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
+    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
 
-            if (ctx->nv_index == 0) {
-                LOG_ERR("NV Index cannot be 0");
-                return false;
-            }
-
-            break;
-        case 'a':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->auth_handle);
-            if (!result) {
-                LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
-
-            if (ctx->auth_handle == 0) {
-                LOG_ERR("Auth handle cannot be 0");
-                return false;
-            }
-            break;
-        case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
-                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                         optarg);
-                 return false;
-             }
-             break;
-        case 'P':
-            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
-            if (!result) {
-                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
-                return false;
-            }
-            break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
-
-    return true;
+    return *opts != NULL;
 }
 
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    (void)opts;
-    (void)envp;
+    UNUSED(flags);
 
-    tpm_nvrelease_ctx ctx = {
-            .auth_handle = 0,
-            .nv_index = 0,
-            .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
-            .sapi_context = sapi_context
-    };
-
-    bool result = init(argc, argv, &ctx);
-    if (!result) {
-        return 1;
-    }
-
-    return nv_space_release(&ctx) != true;
+    return nv_space_release(sapi_context) != true;
 }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <getopt.h>
 #include <limits.h>
 
 #include <sapi/tpm20.h>
@@ -54,17 +53,21 @@ struct tpm_nvwrite_ctx {
     UINT8 nv_buffer[MAX_NV_INDEX_SIZE];
     TPMS_AUTH_COMMAND session_data;
     char *input_file;
-    TSS2_SYS_CONTEXT *sapi_context;
 };
 
-static int nv_write(tpm_nvwrite_ctx *ctx) {
+static tpm_nvwrite_ctx ctx = {
+    .auth_handle = TPM_RH_PLATFORM,
+    .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
+};
+
+static int nv_write(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMS_AUTH_RESPONSE session_data_out;
     TSS2_SYS_CMD_AUTHS sessions_data;
     TSS2_SYS_RSP_AUTHS sessions_data_out;
     TPM2B_MAX_NV_BUFFER nv_write_data;
 
-    TPMS_AUTH_COMMAND *session_data_array[1] = { &ctx->session_data };
+    TPMS_AUTH_COMMAND *session_data_array[1] = { &ctx.session_data };
     TPMS_AUTH_RESPONSE *session_data_out_array[1] = { &session_data_out };
 
     sessions_data_out.rspAuths = &session_data_out_array[0];
@@ -74,44 +77,96 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
     sessions_data.cmdAuthsCount = 1;
 
     UINT16 offset = 0;
-    while (ctx->data_size > 0) {
+    while (ctx.data_size > 0) {
 
         nv_write_data.t.size =
-                ctx->data_size > MAX_NV_BUFFER_SIZE ?
-                MAX_NV_BUFFER_SIZE : ctx->data_size;
+                ctx.data_size > MAX_NV_BUFFER_SIZE ?
+                MAX_NV_BUFFER_SIZE : ctx.data_size;
 
         LOG_INFO("The data(size=%d) to be written:", nv_write_data.t.size);
 
         UINT16 i;
         for (i = 0; i < nv_write_data.t.size; i++) {
-            nv_write_data.t.buffer[i] = ctx->nv_buffer[offset + i];
-            printf("%02x ", ctx->nv_buffer[offset + i]);
+            nv_write_data.t.buffer[i] = ctx.nv_buffer[offset + i];
+            printf("%02x ", ctx.nv_buffer[offset + i]);
         }
         printf("\n\n");
 
-        TPM_RC rval = Tss2_Sys_NV_Write(ctx->sapi_context, ctx->auth_handle,
-                ctx->nv_index, &sessions_data, &nv_write_data, offset,
+        TPM_RC rval = Tss2_Sys_NV_Write(sapi_context, ctx.auth_handle,
+                ctx.nv_index, &sessions_data, &nv_write_data, offset,
                 &sessions_data_out);
         if (rval != TSS2_RC_SUCCESS) {
             LOG_ERR(
                     "Failed to write NV area at index 0x%x (%d) offset 0x%x. Error:0x%x",
-                    ctx->nv_index, ctx->nv_index, offset, rval);
+                    ctx.nv_index, ctx.nv_index, offset, rval);
             return false;
         }
 
         LOG_INFO("Success to write NV area at index 0x%x (%d) offset 0x%x.",
-                ctx->nv_index, ctx->nv_index, offset);
+                ctx.nv_index, ctx.nv_index, offset);
 
-        ctx->data_size -= nv_write_data.t.size;
+        ctx.data_size -= nv_write_data.t.size;
         offset += nv_write_data.t.size;
     }
 
     return true;
 }
 
-static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
+static bool on_option(char key, char *value) {
+    bool result;
 
-    struct option long_options[] = {
+    switch (key) {
+    case 'x':
+        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
+        if (!result) {
+            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.nv_index == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+        }
+        break;
+    case 'a':
+        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        if (!result) {
+            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.auth_handle == 0) {
+            LOG_ERR("Auth handle cannot be 0");
+            return false;
+        }
+        break;
+    case 'f':
+        ctx.input_file = value;
+        break;
+    case 'P':
+        result = tpm2_password_util_from_optarg(value, &ctx.session_data.hmac);
+        if (!result) {
+            LOG_ERR("Invalid handle password, got\"%s\"", value);
+            return false;
+        }
+        break;
+    case 'S':
+        if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {
+            LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
         { "authHandle"  , required_argument, NULL, 'a' },
         { "file"        , required_argument, NULL, 'f' },
@@ -120,94 +175,21 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
         { NULL          , no_argument,       NULL,  0  },
     };
 
-    int opt;
-    bool result;
-    while ((opt = getopt_long(argc, argv, "x:a:f:P:S:", long_options, NULL))
-            != -1) {
-        switch (opt) {
-        case 'x':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->nv_index);
-            if (!result) {
-                LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
+    *opts = tpm2_options_new("x:a:f:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
 
-            if (ctx->nv_index == 0) {
-                LOG_ERR("NV Index cannot be 0");
-                return false;
-            }
-            break;
-        case 'a':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->auth_handle);
-            if (!result) {
-                LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                        optarg);
-                return false;
-            }
+    return *opts != NULL;
+}
 
-            if (ctx->auth_handle == 0) {
-                LOG_ERR("Auth handle cannot be 0");
-                return false;
-            }
-            break;
-        case 'f':
-            ctx->input_file = optarg;
-            break;
-        case 'P':
-            result = tpm2_password_util_from_optarg(optarg, &ctx->session_data.hmac);
-            if (!result) {
-                LOG_ERR("Invalid handle password, got\"%s\"", optarg);
-                return false;
-            }
-            break;
-        case 'S':
-             if (!tpm2_util_string_to_uint32(optarg, &ctx->session_data.sessionHandle)) {
-                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
-                         optarg);
-                 return false;
-             }
-             break;
-        case ':':
-            LOG_ERR("Argument %c needs a value!", optopt);
-            return false;
-        case '?':
-            LOG_ERR("Unknown Argument: %c", optopt);
-            return false;
-        default:
-            LOG_ERR("?? getopt returned character code 0%o ??", opt);
-            return false;
-        }
-    }
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
-    ctx->data_size = MAX_NV_INDEX_SIZE;
-    result = files_load_bytes_from_path(ctx->input_file, ctx->nv_buffer, &ctx->data_size);
+    UNUSED(flags);
+
+    ctx.data_size = MAX_NV_INDEX_SIZE;
+    bool result = files_load_bytes_from_path(ctx.input_file, ctx.nv_buffer, &ctx.data_size);
     if (!result) {
-        LOG_ERR("Failed to read data from %s", ctx->input_file);
+        LOG_ERR("Failed to read data from %s", ctx.input_file);
         return -false;
     }
 
-    return true;
-}
-
-int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
-        TSS2_SYS_CONTEXT *sapi_context) {
-
-    (void)opts;
-    (void)envp;
-
-    tpm_nvwrite_ctx ctx = {
-        .nv_index = 0,
-        .auth_handle = TPM_RH_PLATFORM,
-        .data_size = 0,
-        .session_data = TPMS_AUTH_COMMAND_INIT(TPM_RS_PW),
-        .sapi_context = sapi_context
-    };
-
-    bool result = init(argc, argv, &ctx);
-    if (!result) {
-        return 1;
-    }
-
-    return nv_write(&ctx) != true;
+    return nv_write(sapi_context) != true;
 }

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -146,7 +146,9 @@ int main(int argc, char *argv[], char *envp[]) {
     sapi_teardown_full(sapi_context);
 
 free_opts:
-    tpm2_options_free(tool_opts);
+    if (tool_opts) {
+        tpm2_options_free(tool_opts);
+    }
 
     if (tpm2_tool_onexit) {
         tpm2_tool_onexit();


### PR DESCRIPTION
This is yet another set of tools ported to the new option handling code. While porting this I noticed that my previous ports had some issues:

* I wrongly removed the LOG_ERR() usage in the .on_option handlers because I misunderstood that were not safe to use at some point (but only LOG_INFO and tpm2_tool_output shouldn't be use there).
* I forgot to remove the <getopt.h> header inclusion that's not needed anymore since tools now include "tpm2_options.h".
* Didn't check if tools really needed the sapi_context to be in the context struct. In most cases just the tpm2_tool_onrun() function should pass it to the functions that interact with the TPM.

I'll fix those and propose a patch on top of tpm2-option-revamp.

BTW, I notice a couple of bugs in tpm2_{option,tools}.c so I provide a fix up as a part of this PR.
