### PR TITLE
tpm2_nvread: only print the number of bytes read

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -162,7 +162,7 @@ static bool nv_read(TSS2_SYS_CONTEXT *sapi_context) {
         data_offset += nv_data.t.size;
     }
 
-    hexdump(data_buffer, data_size);
+    hexdump(data_buffer, data_offset);
     result = true;
 
 out:


### PR DESCRIPTION
The nv_read() function queries the NV index public data size to know how
much bytes have to be read. But the reported size may be bigger than the
actual size read from the NV area.

So instead of using the reported NV area public data size for printing,
use the read NV area size.

For example using the NV are public data size may lead to the following:

$ echo -n foobar > data.txt

$ hexdump -C -v data.txt
00000000  66 6f 6f 62 61 72                                 |foobar|
00000006

$ tpm2_nvwrite -x 0x1500018 -a 0x40000001 -f data.txt
66 6f 6f 62 61 72

$ tpm2_nvread -x 0x1500018 -a 0x40000001 -s 6 -o 0
data_size 32 ctx.size_to_read 0 data_offset 6
000000: 66 6f 6f 62 61 72 00 00 c8 ad 07 91 78 7f 00 00  foobar......x...
000010: 10 60 b2 e9 92 55 00 00 05 00 00 00 00 00 00 00  .`...U..........

But after this patch using the read size, the data is correctly printed:

$ tpm2_nvread -x 0x1500018 -a 0x40000001 -s 6 -o 0
000000: 66 6f 6f 62 61 72                                foobar

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>