### PR TITLE
man: update TCTI options man page according to new options handling

### DIFF
--- a/man/tcti-options.troff
+++ b/man/tcti-options.troff
@@ -13,18 +13,15 @@ Supported TCTIs are
 .if (\n[HAVE_TCTI_SOCK]) or \fB\*(lqsocket\*(rq\fR
 .if (\n[HAVE_TCTI_TABRMD]) or \fB\*(lqtabrmd\*(rq\fR
 \[char46]
+Additional options for the TCTI can be specified after the TCTI name by adding a
+: as prefix.
 .TP
 .if (\n[HAVE_TCTI_DEV]) \{
-\fB\-d,\ \-\-device-file\fR
-Specify the TPM device file for use by the device TCTI. The default is
-/dev/tpm0.
+For the device TCTI, the TPM device file for use by the device TCTI can be specified.
+The default is /dev/tpm0. Example: -T device:/dev/tpm0
 \}
 .if (\n[HAVE_TCTI_SOCK]) \{
 .TP
-\fB\-R,\ \-\-socket-address\fR
-Specify the domain name or IP address used by the socket TCTI. The default
-is 127.0.0.1.
-.TP
-\fB\-p,\ \-\-socket-port\fR
-Specify the port number used by the socket TCTI. The default is 2321.
+For the socket TCTI, the domain name or IP address and port number used by the socket
+can be specified. The default are 127.0.0.1 and 2321. Example: -T socket:127.0.0.1:2321
 \}


### PR DESCRIPTION
Commit 1cb24d62d6b ("option fixing: move to single getopt") reworked how
the options are handled by the tools, but it also changed how the TCTI
specific options are passed to the TCTI initialization code.

The man pages were not updated and still list the old way to specify the
TCTI specific options, users reading the man page will face this issue:

$ tpm2_pcrlist -L sha1:7 -T device -d /dev/tpm0
tpm2_pcrlist: invalid option -- 'd'
ERROR: Unknown Argument: d

Update man pages so users know that they instead need to do following:

$ tpm2_pcrlist -L sha1:7 -T device:/dev/tpm0

Bank/Algorithm: sha(0x0004)
PCR_07:6d7206871c9c6f38ad3997baceebee95dadec04d

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>