### PR TITLE
test: make sure temp files are cleaned up on test_tpm2_nv.sh exit

### DIFF
--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -38,6 +38,10 @@ large_file_name="nv.test_large_w"
 large_file_read_name="nv.test_large_w"
 
 cleanup() {
+ tpm2_nvlist|grep -i $nv_test_index
+ if [ $? = 0 ];then
+  tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle
+ fi
  rm -f policy.bin test.bin nv.test_w 2> /dev/null
  rm -f $large_file_name $large_file_read_name 2> /dev/null
  rm -f nv.readlock 2> /dev/null
@@ -45,89 +49,41 @@ cleanup() {
 
 trap cleanup EXIT
 
+onerror() {
+    echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+    exit 1
+}
+trap onerror ERR
+
 cleanup
 
 tpm2_takeownership -c 
- if [ $? != 0 ];then 
- echo "clean ownership Fail!"
- exit 1
- fi
-tpm2_nvlist|grep -i $nv_test_index
-if [ $? = 0 ];then
-tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle 
- if [ $? != 0 ];then 
- echo "please release the nv index $nv_test_index first!"
- exit 1
- fi
-fi
 
 tpm2_nvdefine -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite"
-if [ $? != 0 ];then 
- echo "nvdefine fail,Please check your environment!"
- exit 1
-fi
-
 
 if [ ! -f nv.test_w ];then
  echo "please123abc" >nv.test_w
 fi
 
 tpm2_nvwrite -x $nv_test_index -a $nv_auth_handle  -f nv.test_w 
-if [ $? != 0 ];then 
- echo "nvwrite fail!"
- exit 1
-fi
 
 tpm2_nvread -x $nv_test_index -a $nv_auth_handle  -s 32 -o 0
 
-if [ $? != 0 ];then 
- echo "nvread fail!"
- exit 1
-fi
-
 tpm2_nvlist|grep -i $nv_test_index
-if [ $? != 0 ];then 
- echo "nvlist  fail or double check the define index!"
- exit 1
-fi
 
 tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle  
-
-if [ $? != 0 ];then 
- echo "nvrelease  fail or double check the define index!"
- exit 1
-else
- echo "release the nv index OK!"
-fi
-
 
 echo "f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988" \
 | xxd -r -p > policy.bin
 
 tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A -L policy.bin -t "ownerread|ownerwrite|policywrite|policyread"
-if [ $? != 0 ];then
- echo "Failed tpm2_nvdefine"
- exit 1
-fi
 
 tpm2_nvlist | grep 0x1500016 -A5 | grep Auth | grep -o ": [a-zA-Z0-9]\{1,\}" | \
 grep -o "[a-zA-Z0-9]\{1\}" | xxd -r -p >test.bin
-if [ $? != 0 ];then
- echo "Failed tpm2_nvlist"
- exit 1
-fi
 
 cmp test.bin policy.bin -s
-if [ $? != 0 ];then
- echo "nvdefine with policy in authorization structure failed"
- exit 1
-fi
 
 tpm2_nvrelease -x 0x1500016 -a 0x40000001
-if [ $? != 0 ];then
- echo "nvrelease failed"
- exit 1
-fi
 
 #
 # Test large writes
@@ -137,43 +93,18 @@ nv_test_index=0x1000000
 
 # Create an nv space with attributes 1010 = TPMA_NV_PPWRITE and TPMA_NV_AUTHWRITE
 tpm2_nvdefine -x $nv_test_index -a $nv_auth_handle -s $large_file_size -t 0x2000A
-if [ $? != 0 ];then
- echo "nvdefine failed for a size of $large_file_size"
- exit 1
-fi
 
 if [ ! -f $large_file_name ]; then
   base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
-  if [ $? != 0 ];then
-    echo "creating large file $large_file_name failed"
-    exit 1
-  fi
 fi
 
 tpm2_nvwrite -x $nv_test_index -a $nv_auth_handle  -f $large_file_name
-if [ $? != 0 ];then
-  echo "nvwrite failed for testing large writes!"
-  exit 1
-fi
 
 tpm2_nvread -x $nv_test_index -a $nv_auth_handle | xxd -r > $large_file_read_name
-if [ $? != 0 ];then
-  echo "nvread failed for testing large reads!"
-  exit 1
-fi
 
 cmp -s $large_file_read_name $large_file_name
 
-rc=$?
-if [ $rc != 0 ]; then
-  echo "Comparing the written and read large files failed with: $rc"
-fi
-
 tpm2_nvlist|grep -i $nv_test_index
-if [ $? != 0 ];then
-  echo "nvlist  fail or double check the define index!"
-  exit 1
-fi
 
 tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle
 
@@ -181,39 +112,21 @@ tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle
 # Test NV access locked
 #
 tpm2_nvdefine -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite|read_stclear"
-if [ $? != 0 ];then
- echo "nvdefine failed!"
- exit 1
-fi
 
 echo "foobar" > nv.readlock
 
 tpm2_nvwrite -x $nv_test_index -a $nv_auth_handle -f nv.readlock
-if [ $? != 0 ];then
- echo "nvwrite failed!"
- exit 1
-fi
 
 tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s 6 -o 0
-if [ $? != 0 ];then
- echo "nvread failed!"
- exit 1
-fi
 
 tpm2_nvreadlock -x $nv_test_index -a $nv_auth_handle
-if [ $? != 0 ];then
- echo "nvreadlock failed!"
-fi
+
+# Reset ERR signal handler to test for expected nvread error
+trap - ERR
 
 tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s 6 -o 0 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
- exit 1
-fi
-
-tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle
-if [ $? != 0 ];then
- echo "nvrelease failed!"
  exit 1
 fi
 


### PR DESCRIPTION
If the test is interrupted, then temporary files may not be cleaned up
correctly. Ensure that the files are always removed on the script exit.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>