### PR TITLE
man: explain in tpm2_evictcontrol page how objects are evicted

### DIFF
--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -26,7 +26,13 @@ OPTIONS
     *  `p` for `TPM_RH_PLATFORM`
 
   * `-H`, `--handle`=_HANDLE_:
-    The handle of a loaded object.
+    The handle of a loaded transient or a persistent object.
+
+    If the handle is for a transient object, then a handle that will be assigned to the persisted
+    object must also be specified with the `-S` option.
+
+    If the handle is for a persistent object, then the same handle has to be specified with the
+    `-S` option for the persistent object to be evicted.
 
   * `-c`, `--context`=_OBJECT\_CONTEXT\_FILE_:
     Filename for object context.
@@ -49,7 +55,7 @@ EXAMPLES
 ```
 tpm2_evictcontrol -A o -c object.context -S 0x81010002 -P abc123
 tpm2_evictcontrol -A o -H 0x81010002 -S 0x81010002 -P abc123
-tpm2_evictcontrol -A o -H 0x81010002 -S 0x81010002 -P 123abc -X
+tpm2_evictcontrol -A o -H 0x81010002 -S 0x81010002 -P 123abc
 ```
 
 RETURNS


### PR DESCRIPTION
The specification says "If objectHandle is a persistent object, then the
call evicts the persistent object" and "if objectHandle is a persistent
object handle, then it shall be the same value as persistentHandle".

So the tool is doing the correct thing by requiring both the object and
persistent handles to be defined and being the same to evict an object.

But this isn't documented in the tool man page and it may not be evident
to people not familiar with the TCG TPM specification.

While being there, remove a -X option from one of the examples since the
tpm2_evictcontrol tool doesn't have one.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>