### PR TITLE
tpm2_evictcontrol: make tool smarter to not require -S to evict objects

### DIFF
--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -31,8 +31,8 @@ OPTIONS
     If the handle is for a transient object, then a handle that will be assigned to the persisted
     object must also be specified with the `-S` option.
 
-    If the handle is for a persistent object, then the same handle has to be specified with the
-    `-S` option for the persistent object to be evicted.
+    If the handle is for a persistent object, then the `-S` does not need to be provided since the
+    handle must be the same for both options.
 
   * `-c`, `--context`=_OBJECT\_CONTEXT\_FILE_:
     Filename for object context.

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -120,6 +120,11 @@ static bool on_option(char key, char *value) {
             return false;
         }
         ctx.flags.H = 1;
+
+        if (ctx.handle.object >> HR_SHIFT == TPM_HT_PERSISTENT) {
+            ctx.handle.persist = ctx.handle.object;
+            ctx.flags.S = 1;
+        }
         break;
     case 'S':
         result = tpm2_util_string_to_uint32(value, &ctx.handle.persist);


### PR DESCRIPTION
The TCG TPM specification requires the same handle to be provided for both
objectHandle and persistentHandle but this implementation detail leaked in
the tool and so users need to provide both a -S and -H options to evict an
object.

But the tool can be smarter, the handles are not just opaque values but
they encode information. The first byte is the TPM_HT (Handle Type) and
for persistent objects handles this is TPM_HT_PERSISTENT (0x81).

Fixes: #492

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>