### PR TITLE
tpm2_load: don't make -n option to be required

### DIFF
--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -21,7 +21,7 @@ OPTIONS
 -----------
 
   * `-H`, `--parent`=_PARENT\_HANDLE_:
-    The handle of the parent object.
+    The handle of the parent object. Either this option or `-c` must be used.
 
   * `-c`, `--contextParent`=_PARENT\_CONTEXT\_FILE_:
     The filename for parent context.
@@ -37,7 +37,7 @@ OPTIONS
     A file containing the sensitive portion of the object.
 
   * `-n`, `--name`=_NAME\_DATA\_FILE_:
-    A file containing the name structure of the object.
+    An optional file to save the name structure of the object.
 
   * `-C`, `--name`=_CONTEXT\_FILE_:
     An optional file to save the object context to.


### PR DESCRIPTION
The tool requires the option for a file path to store the structure name
of the object, but this shouldn't really be a required option. In fact,
the whole option checking seems bogus so just check for the options that
should be required and not the ones that should be optional.

While being there, make this clear in the man page as well.

Fixes: #494

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>