### PR TITLE
Fix for hierarchy authentication password overwriting the primary object's authentication password

### DIFF
--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -45,6 +45,12 @@
 #define TPM2B_TYPE_INIT(type, field) { .t = { .size = BUFFER_SIZE(type, field), }, }
 #define TPM2B_INIT(xsize) { .t = { .size = xsize, }, }
 #define TPM2B_EMPTY_INIT TPM2B_INIT(0)
+#define TPM2B_SENSITIVE_CREATE_EMPTY_INIT { \
+           .t.sensitive = { \
+                .data.t.size = 0, \
+                .userAuth.b.size = 0, \
+            }, \
+    }
 #define SESSION_ATTRIBUTES_INIT(mask) { .val = mask }
 
 #define TPMS_AUTH_COMMAND_INIT(session_handle) { \


### PR DESCRIPTION
Fix for issue #500