### PR TITLE
tpm2_listpersistent: check that -g and -G correct values were provided

### DIFF
--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -62,14 +62,16 @@ static bool on_option(char key, char *value) {
     switch (key) {
     case 'g':
         ctx.nameAlg = tpm2_alg_util_from_optarg(value);
-        if(ctx.nameAlg == TPM_ALG_ERROR) {
+        if(ctx.nameAlg == TPM_ALG_ERROR ||
+           !tpm2_alg_util_is_hash_alg(ctx.nameAlg)) {
             LOG_ERR("Invalid hash algorithm, got \"%s\"", value);
             return false;
         }
         break;
     case 'G':
         ctx.type = tpm2_alg_util_from_optarg(value);
-        if(ctx.type == TPM_ALG_ERROR) {
+        if(ctx.type == TPM_ALG_ERROR ||
+           tpm2_alg_util_is_hash_alg(ctx.type)) {
             LOG_ERR("Invalid key algorithm, got \"%s\"", value);
             return false;
         }


### PR DESCRIPTION
The tool is using the tpm2_alg_util_from_optarg() function to convert from
the pretty names provided by the user to the hexadecimal algorithm values.

But the same function is used to convert both key and hash algorithms and
so using a key as a hash and viceversa was wrongly taken as correct value.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>