### PR TITLE
tpm2_create: rename options for public and sensitive portions of the …

### DIFF
--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -60,11 +60,11 @@ These options for creating the tpm entity:
   * `-E`, `--enforce-policy`:
     Enforce policy based authorization on the object.
 
-  * `-o`, `--opu`=_OUTPUT\_PUBLIC\_FILE_:
-    The output file which contains the public key, optional.
+  * `-u`, `--pubfile`=_OUTPUT\_PUBLIC\_FILE_:
+    The output file which contains the public portion of the created object, optional.
 
-  * `-O`, `--opr`=_OUTPUT\PRIVATE\_FILE_:
-    The output file which contains the private key, optional.
+  * `-r`, `--privfile`=_OUTPUT\_PRIVATE\_FILE_:
+    The output file which contains the sensitive portion of the object, optional.
 
 * `-S`, `--input-session-handle`=_SESSION\_HANDLE_:
     Optional Input session handle from a policy session for authorization.

--- a/test/system/test_algs.sh
+++ b/test/system/test_algs.sh
@@ -56,7 +56,7 @@ for  halg_p in 0x0004 0x000B 0x000C 0x000D 0x0012
  do
 	for kalg_c in 0x0001 0x0008 0x0023 0x0025
 	 do
-     tpm2_create  -g $halg_c  -G $kalg_c -o opu_"$halg_p""$kalg_p"_"$halg_c""$kalg_c" -O opr_"$halg_p""$kalg_p"_"$halg_c""$kalg_c"  -c context.p_"$halg_p"_"$kalg_p"
+     tpm2_create  -g $halg_c  -G $kalg_c -u opu_"$halg_p""$kalg_p"_"$halg_c""$kalg_c" -r opr_"$halg_p""$kalg_p"_"$halg_c""$kalg_c"  -c context.p_"$halg_p"_"$kalg_p"
     
 		if [ $? != 0 ];then
 		echo "create used context.p_"$halg_p"_"$kalg_p" with algs:"$halg_c""$kalg_c" fail, please check the environment or parameters!" 

--- a/test/system/test_algs_tpm2_unseal.sh
+++ b/test/system/test_algs_tpm2_unseal.sh
@@ -61,7 +61,7 @@ for  halg_p in 0x0004 0x000B 0x000C 0x000D 0x0012
  do
 	for kalg_c in 0x0001 0x0008 0x0023 0x0025
 	 do
-     tpm2_create  -g $halg_c  -G $kalg_c -o opu_"$halg_p""$kalg_p"_"$halg_c""$kalg_c" -O opr_"$halg_p""$kalg_p"_"$halg_c""$kalg_c"  -I secret.data  -c context.p_"$halg_p"_"$kalg_p"
+     tpm2_create  -g $halg_c  -G $kalg_c -u opu_"$halg_p""$kalg_p"_"$halg_c""$kalg_c" -r opr_"$halg_p""$kalg_p"_"$halg_c""$kalg_c"  -I secret.data  -c context.p_"$halg_p"_"$kalg_p"
     
 		if [ $? != 0 ];then
 		echo "create used context.p_"$halg_p"_"$kalg_p" with algs:"$halg_c""$kalg_c" fail, please check the environment or parameters!" 

--- a/test/system/test_smoking.sh
+++ b/test/system/test_smoking.sh
@@ -111,7 +111,7 @@ tpm2_createprimary -A p -g 0x0004 -G 0x001 -C context.p1.out
 	fail createprimary
   fi
 
-tpm2_create -c context.p1.out -g 0x000B -G 0x0008 -o opu1.out -O opr1.out -I secret.data 
+tpm2_create -c context.p1.out -g 0x000B -G 0x0008 -u opu1.out -r opr1.out -I secret.data
   if [ $? != 0 ];then
 	fail create
   fi
@@ -129,7 +129,7 @@ tpm2_createprimary -A p -g 0x000B -G 0x001 -C context.p2.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create -c context.p2.out -g 0x000B -G 0x0008 -o opu2.out -O opr2.out 
+tpm2_create -c context.p2.out -g 0x000B -G 0x0008 -u opu2.out -r opr2.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -147,7 +147,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p3.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create  -c  context.p3.out -g 0x000B -G 0x0008  -o opu3.out -O opr3.out
+tpm2_create  -c  context.p3.out -g 0x000B -G 0x0008  -u opu3.out -r opr3.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -165,7 +165,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p4.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create  -c  context.p4.out -g 0x000B -G 0x0008  -o opu4.out -O opr4.out
+tpm2_create  -c  context.p4.out -g 0x000B -G 0x0008  -u opu4.out -r opr4.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -183,7 +183,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p5.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create -g 0x000B -G 0x0008 -o opu5.out -O opr5.out -c context.p5.out
+tpm2_create -g 0x000B -G 0x0008 -u opu5.out -r opr5.out -c context.p5.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -206,7 +206,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p6.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create  -g 0x000B -G 0x0001 -o opu6.out -O opr6.out -c context.p6.out
+tpm2_create  -g 0x000B -G 0x0001 -u opu6.out -r opr6.out -c context.p6.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -233,7 +233,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p7.out
 	fail createprimary 
   fi
   
-tpm2_create -g 0x000B -G 0x0008 -o opu7.out -O opr7.out -c context.p7.out
+tpm2_create -g 0x000B -G 0x0008 -u opu7.out -r opr7.out -c context.p7.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -256,7 +256,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p8.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create  -g 0x000B -G 0x0025 -o opu8.out -O opr8.out -c context.p8.out
+tpm2_create  -g 0x000B -G 0x0025 -u opu8.out -r opr8.out -c context.p8.out
   if [ $? != 0 ];then
 	fail create 
   fi
@@ -278,7 +278,7 @@ tpm2_createprimary -A e -g 0x000B -G 0x0001 -C context.p9.out
   if [ $? != 0 ];then
 	fail createprimary 
   fi
-tpm2_create -g 0x000B -G 0x0001 -o opu9.out -O opr9.out -c context.p9.out 
+tpm2_create -g 0x000B -G 0x0001 -u opu9.out -r opr9.out -c context.p9.out
   if [ $? != 0 ];then
 	fail create 
   fi

--- a/test/system/test_tpm2_certify.sh
+++ b/test/system/test_tpm2_certify.sh
@@ -53,7 +53,7 @@ if [ $? != 0 ];then
 echo "createprimary fail, please check the environment or parameters!"
 exit 1
 fi
-tpm2_create -g $alg_hash -G $alg_certify_key -o $file_certify_key_pub -O $file_certify_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_certify_key -u $file_certify_key_pub -r $file_certify_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "create fail, please check the environment or parameters!"
 exit 1

--- a/test/system/test_tpm2_create_all.sh
+++ b/test/system/test_tpm2_create_all.sh
@@ -52,7 +52,7 @@ for pCtx in `ls ctx.cpri*`
         do 
         for GAlg in rsa 0x08 ecc 0x25
             do 
-            tpm2_create -c $pCtx -g $gAlg -G $GAlg -o opu."$pCtx".g"$gAlg".G"$GAlg" -O opr."$pCtx".g"$gAlg".G"$GAlg"
+            tpm2_create -c $pCtx -g $gAlg -G $GAlg -u opu."$pCtx".g"$gAlg".G"$GAlg" -r opr."$pCtx".g"$gAlg".G"$GAlg"
             if [ $? != 0 ];then 
             echo "tpm2_create error: pCtx=$pCtx gAlg=$gAlg GAlg=$GAlg"
             echo "tpm2_create error: pCtx=$pCtx gAlg=$gAlg GAlg=$GAlg" >> create.error.log             
@@ -70,7 +70,7 @@ if [ $? != 0 ];then
  exit 1
 fi
 
-tpm2_create -c prim.ctx -g sha256 -G 0x1 -L policy.bin -o key.pub -O key.priv -E
+tpm2_create -c prim.ctx -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv -E
 if [ $? != 0 ];then
  echo "create object failed"
  exit 1

--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -78,7 +78,7 @@ tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary
 if [ $? != 0 ];then
 	 fail createprimary 
 fi
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_en_decrypt_key_pub -O $file_en_decrypt_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_en_decrypt_key_pub -r $file_en_decrypt_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 fi

--- a/test/system/test_tpm2_evictcontrol.sh
+++ b/test/system/test_tpm2_evictcontrol.sh
@@ -53,7 +53,7 @@ if [ $? != 0 ];then
  echo "createprimary fail, please check the environment or parameters!"
  exit 1
 fi
-tpm2_create -g $alg_hash -G $alg_evict_key -o $file_evict_key_pub -O $file_evict_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_evict_key -u $file_evict_key_pub -r $file_evict_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
  echo "create fail, please check the environment or parameters!"
  exit 1

--- a/test/system/test_tpm2_hmac.sh
+++ b/test/system/test_tpm2_hmac.sh
@@ -74,7 +74,7 @@ tpm2_takeownership -c
 
 tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_hmac_key_pub -O $file_hmac_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -c $file_primary_key_ctx
 
 tpm2_load -c $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -C $file_hmac_key_ctx
 
@@ -104,7 +104,7 @@ tpm2_takeownership -c
 
 tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
-tpm2_create -g sha1 -G $alg_create_key -o $file_hmac_key_pub -O $file_hmac_key_priv  -c $file_primary_key_ctx
+tpm2_create -g sha1 -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -c $file_primary_key_ctx
 
 tpm2_load -c $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -C $file_hmac_key_ctx
 

--- a/test/system/test_tpm2_load.sh
+++ b/test/system/test_tpm2_load.sh
@@ -67,7 +67,7 @@ tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary
 if [ $? != 0 ];then
 	 fail createprimary 
 fi
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_load_key_pub -O $file_load_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 fi
@@ -84,7 +84,7 @@ tpm2_evictcontrol -A o -c $file_primary_key_ctx  -S $Handle_parent
 if [ $? != 0 ];then
 	fail evict   
 fi
-tpm2_create  -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -o $file_load_key_pub  -O  $file_load_key_priv  
+tpm2_create  -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_load_key_pub  -r  $file_load_key_priv
 if [ $? != 0 ];then
 	fail create 
 fi

--- a/test/system/test_tpm2_loadexternal.sh
+++ b/test/system/test_tpm2_loadexternal.sh
@@ -63,7 +63,7 @@ tpm2_takeownership -c
 
 tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_loadexternal_key_pub -O $file_loadexternal_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r $file_loadexternal_key_priv  -c $file_primary_key_ctx
 
 tpm2_loadexternal -H n   -u $file_loadexternal_key_pub   -C $file_loadexternal_key_ctx
 
@@ -72,7 +72,7 @@ tpm2_evictcontrol -A o -c $file_primary_key_ctx  -S $Handle_parent
 # Test with Handle
 cleanup
 
-tpm2_create  -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -o $file_loadexternal_key_pub  -O  $file_loadexternal_key_priv
+tpm2_create  -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_loadexternal_key_pub  -r  $file_loadexternal_key_priv
 
 tpm2_loadexternal  -H n   -u $file_loadexternal_key_pub
 

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -73,7 +73,7 @@ if [ $? != 0 ];then
 	 fail createprimary 
 	 exit 1
 fi
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_quote_key_pub -O $file_quote_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 	exit 1

--- a/test/system/test_tpm2_readpublic.sh
+++ b/test/system/test_tpm2_readpublic.sh
@@ -62,7 +62,7 @@ tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary
 if [ $? != 0 ];then
 	 fail createprimary 
 fi
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_readpub_key_pub -O $file_readpub_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 fi

--- a/test/system/test_tpm2_rsadecrypt.sh
+++ b/test/system/test_tpm2_rsadecrypt.sh
@@ -58,7 +58,7 @@ if [ $? != 0 ];then
 echo "createprimary fail, please check the environment or parameters!"
 exit 1
 fi
-tpm2_create -g $alg_hash -G $alg_rsaencrypt_key -o $file_rsaencrypt_key_pub -O $file_rsaencrypt_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "create fail, please check the environment or parameters!"
 exit 1

--- a/test/system/test_tpm2_rsaencrypt.sh
+++ b/test/system/test_tpm2_rsaencrypt.sh
@@ -56,7 +56,7 @@ if [ $? != 0 ];then
 echo "createprimary fail, please check the environment or parameters!"
 exit 1
 fi
-tpm2_create -g $alg_hash -G $alg_rsaencrypt_key -o $file_rsaencrypt_key_pub -O $file_rsaencrypt_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "create fail, please check the environment or parameters!"
 exit 1

--- a/test/system/test_tpm2_sign.sh
+++ b/test/system/test_tpm2_sign.sh
@@ -69,7 +69,7 @@ tpm2_createprimary -A e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ct
 if [ $? != 0 ];then
 	 fail createprimary 
 fi
-tpm2_create -g $alg_hash -G $alg_signing_key -o $file_signing_key_pub -O $file_signing_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 fi

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -66,7 +66,7 @@ echo "createprimary fail, please check the environment or parameters!"
 exit 1
 fi
 
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_unseal_key_pub -O $file_unseal_key_priv  -I $file_input_data -c $file_primary_key_ctx
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv  -I $file_input_data -c $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "create fail, please check the environment or parameters!"
 exit 1
@@ -106,7 +106,7 @@ if [ $? != 0 ];then
     exit 1
 fi
 
-tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_unseal_key_pub -O $file_unseal_key_priv -I- -c $file_primary_key_ctx -L $file_policy -A $obj_attr <<< $secret
+tpm2_create -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -c $file_primary_key_ctx -L $file_policy -A $obj_attr <<< $secret
 if [ $? != 0 ];then
     echo "create object with policy fail, please check the environment or parameters!"
     exit 1

--- a/test/system/test_tpm2_verifysignature.sh
+++ b/test/system/test_tpm2_verifysignature.sh
@@ -71,7 +71,7 @@ tpm2_createprimary -A e -g $alg_hash -G $alg_primary_key -C $file_primary_key_ct
 if [ $? != 0 ];then
 	 fail createprimary 
 fi
-tpm2_create -g $alg_hash -G $alg_signing_key -o $file_signing_key_pub -O $file_signing_key_priv  -c $file_primary_key_ctx
+tpm2_create -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -c $file_primary_key_ctx
 if [ $? != 0 ];then
 	fail create 
 fi

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -313,14 +313,14 @@ static bool on_option(char key, char *value) {
     case 'E':
         ctx.is_policy_enforced = true;
         break;
-    case 'o':
+    case 'u':
         ctx.opu_path = value;
         if(files_does_file_exist(ctx.opu_path) != 0) {
             return false;
         }
         ctx.flags.o = 1;
         break;
-    case 'O':
+    case 'r':
         ctx.opr_path = value;
         if(files_does_file_exist(ctx.opr_path) != 0) {
             return false;
@@ -351,8 +351,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"inFile",1,NULL,'I'},
       {"policy-file",1,NULL,'L'},
       {"enforce-policy",1,NULL,'E'},
-      {"opu",1,NULL,'o'},
-      {"opr",1,NULL,'O'},
+      {"pubfile",1,NULL,'u'},
+      {"privfile",1,NULL,'r'},
       {"contextParent",1,NULL,'c'},
       {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
@@ -361,7 +361,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     setbuf(stdout, NULL);
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
-    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:o:O:c:S:E", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("H:P:K:g:G:A:I:L:u:r:c:S:E", ARRAY_LEN(topts), topts, on_option, NULL);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
…object

Next release will already not be backward compatible due a lot of changes,
so let's change the tpm2_create options for the file paths to store public
and sensitive portions of the created object to be consistent with how the
other tools use for these options.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>