### PR TITLE
test: fix test errors with test_tpm2_pcrevent.sh

### DIFF
--- a/test/system/test_tpm2_pcrevent.sh
+++ b/test/system/test_tpm2_pcrevent.sh
@@ -62,6 +62,12 @@ cat $hash_in_file | tpm2_pcrevent > $hash_out_file
 # Verify output as expected.
 for l in `cat $hash_out_file`; do
   alg=`echo -n $l | cut -d\: -f 1-1`
+
+  if ! which "$alg"sum >/dev/null 2>&1; then
+      echo "Ignore checking $alg algorithm due to unavailable \"${alg}sum\" program"
+      continue
+  fi
+
   hash=`echo -n $l | cut -d\: -f 2-2`
   check=`"$alg"sum $hash_in_file | cut -d' ' -f 1-1`
   if [ "$check" != "$hash" ]; then


### PR DESCRIPTION
The returned identify of sha1 algorithm may be "sha" and thus calling
shasum rather than sha1sum will fail for sure. Fix the alg if returning
"sha".

In addition, there is no equivalent like sha256sum for sm3_256.
Currently we simply ignore testing this sort of hash algorithm.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>