### PR TITLE
tpm2_createpolicy: add new line to extend policy session handle output

### DIFF
--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -138,7 +138,7 @@ static TPM_RC parse_policy_type_specific_command(TSS2_SYS_CONTEXT *sapi_context)
     }
 
     if (pctx.common_policy_options.extend_policy_session) {
-        tpm2_tool_output("EXTENDED_POLICY_SESSION_HANDLE: 0x%08X",
+        tpm2_tool_output("EXTENDED_POLICY_SESSION_HANDLE: 0x%08X\n",
             pctx.common_policy_options.policy_session->sessionHandle );
     }
 


### PR DESCRIPTION
The tpm2_tool_output() doesn't add a new line character like the LOG_*()
macros, add one so the session handle information is printed correctly.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>