### PR TITLE
travis: install pandoc to build man pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
     - libdbus-1-dev
     - libglib2.0-dev
     - clang-3.8
-    - ruby-dev
+    - pandoc
 
 env:
   global:
@@ -38,15 +38,6 @@ env:
 before_install:
     - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
     - pip install --user cpp-coveralls pyyaml
-    - rvm list
-    # RVM didn't play nicely with the redcarpet and kept stating that the library it was loading
-    # was invalid, so we nuke it here. Note that you may need new invocations of shell to avoid
-    # a polluted rvm environment.
-    - rvm implode --force
-    - gem uninstall --force rvm || true
-    - bash -c 'sudo gem install md2man'
-    # Fail early if ruby is acting up.
-    - bash -c 'echo "foo\n===" | md2man-roff'
 
 install: 
     - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar


### PR DESCRIPTION
The commit fd034b2fe2f0 ("man: use pandoc instead of md2man for man pages
generation") replaced the tool used to generate the man pages. But forgot
to update the Travis CI yaml, to install pandoc so man pages are created.

Using pandoc will also have the side effects of getting rid of the ruby
version manager shenanigans that were in the Travis configuration file.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>