### PR TITLE
Fixes for 2.1.0 (2.X branch)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -209,6 +209,9 @@ endif
 if HAVE_TCTI_SOCK
 	echo ".nr HAVE_TCTI_SOCK 1" >> $@
 endif
+if HAVE_TCTI_TABRMD
+	echo ".nr HAVE_TCTI_TABRMD 1" >> $@
+endif
 	sed -e '/@COMMON_OPTIONS_INCLUDE@/r man/common-options.troff' \
 	    -e '/@COMMON_OPTIONS_INCLUDE@/d' \
 	    -e '/@TCTI_OPTIONS_INCLUDE@/r man/tcti-options.troff' \

--- a/tools/main.c
+++ b/tools/main.c
@@ -61,7 +61,7 @@ main (int   argc,
         execute_man (argv[0], envp);
         fprintf (stderr,
                  "failed to load manpage, check your environment / PATH\n");
-        /* no break */
+        /* fallthrough */
     case 2:
         exit (1);
     }

--- a/tools/tpm2_dump_capability.c
+++ b/tools/tpm2_dump_capability.c
@@ -595,7 +595,7 @@ dump_tpm_capability (TPMU_CAPABILITIES    *capabilities,
     case TPM_CAP_COMMANDS:
         dump_command_attr_array (capabilities->command.commandAttributes,
                                  capabilities->command.count);
-        /* no break */
+        /* fallthrough */
     default:
         return 1;
     }

--- a/tools/tpm2_listpcrs.c
+++ b/tools/tpm2_listpcrs.c
@@ -63,6 +63,7 @@ struct listpcr_context {
     tpm2_algorithm algs;
     tpm2_pcrs pcrs;
     TPML_PCR_SELECTION pcr_selections;
+    TPMS_CAPABILITY_DATA cap_data;
 };
 
 static inline void set_pcr_select_bit(TPMS_PCR_SELECTION *pcr_selection,
@@ -175,26 +176,19 @@ static bool read_pcr_values(listpcr_context *context) {
 
 static bool init_pcr_selection(TPMI_ALG_HASH alg_id, listpcr_context *context) {
 
-    TPMI_YES_NO moreData;
-    TPMS_CAPABILITY_DATA cap_data;
+    TPMS_CAPABILITY_DATA *cap_data = &context->cap_data;
     TPML_PCR_SELECTION *pcr_sel = &context->pcr_selections;
-    UINT32 rval, i, j;
-
-    rval = Tss2_Sys_GetCapability(context->sapi_context, 0, TPM_CAP_PCRS, 0, 1, &moreData, &cap_data, 0);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n", rval);
-        return false;
-    }
+    UINT32 i, j;
 
     pcr_sel->count = 0;
 
-    for (i = 0; i < cap_data.data.assignedPCR.count; i++) {
-        if (alg_id && (cap_data.data.assignedPCR.pcrSelections[i].hash != alg_id))
+    for (i = 0; i < cap_data->data.assignedPCR.count; i++) {
+        if (alg_id && (cap_data->data.assignedPCR.pcrSelections[i].hash != alg_id))
             continue;
-        pcr_sel->pcrSelections[pcr_sel->count].hash = cap_data.data.assignedPCR.pcrSelections[i].hash;
-        set_pcr_select_size(&pcr_sel->pcrSelections[pcr_sel->count], cap_data.data.assignedPCR.pcrSelections[i].sizeofSelect);
+        pcr_sel->pcrSelections[pcr_sel->count].hash = cap_data->data.assignedPCR.pcrSelections[i].hash;
+        set_pcr_select_size(&pcr_sel->pcrSelections[pcr_sel->count], cap_data->data.assignedPCR.pcrSelections[i].sizeofSelect);
         for (j = 0; j < pcr_sel->pcrSelections[pcr_sel->count].sizeofSelect; j++)
-            pcr_sel->pcrSelections[pcr_sel->count].pcrSelect[j] = cap_data.data.assignedPCR.pcrSelections[i].pcrSelect[j];
+            pcr_sel->pcrSelections[pcr_sel->count].pcrSelect[j] = cap_data->data.assignedPCR.pcrSelections[i].pcrSelect[j];
         pcr_sel->count++;
     }
 
@@ -285,11 +279,11 @@ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id) 
 static bool get_banks(listpcr_context *context) {
 
     TPMI_YES_NO more_data;
-    TPMS_CAPABILITY_DATA capability_data;
+    TPMS_CAPABILITY_DATA *capability_data = &context->cap_data;
     UINT32 rval;
 
     rval = Tss2_Sys_GetCapability(context->sapi_context, 0, TPM_CAP_PCRS, 0, 1,
-            &more_data, &capability_data, 0);
+            &more_data, capability_data, 0);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR(
                 "GetCapability: Get PCR allocation status Error. TPM Error:0x%x......\n",
@@ -298,11 +292,11 @@ static bool get_banks(listpcr_context *context) {
     }
 
     unsigned i;
-    for (i = 0; i < capability_data.data.assignedPCR.count; i++) {
+    for (i = 0; i < capability_data->data.assignedPCR.count; i++) {
         context->algs.alg[i] =
-                capability_data.data.assignedPCR.pcrSelections[i].hash;
+                capability_data->data.assignedPCR.pcrSelections[i].hash;
     }
-    context->algs.count = capability_data.data.assignedPCR.count;
+    context->algs.count = capability_data->data.assignedPCR.count;
 
     return true;
 }

--- a/tools/tpm2_listpcrs.c
+++ b/tools/tpm2_listpcrs.c
@@ -198,6 +198,62 @@ static bool init_pcr_selection(TPMI_ALG_HASH alg_id, listpcr_context *context) {
     return true;
 }
 
+static void shrink_pcr_selection(TPML_PCR_SELECTION *s) {
+
+    UINT32 i, j;
+
+    //seek for the first empty item
+    for (i = 0; i < s->count; i++)
+        if (!s->pcrSelections[i].hash)
+            break;
+    j = i + 1;
+
+    for (; i < s->count; i++) {
+        if (!s->pcrSelections[i].hash) {
+            for (; j < s->count; j++)
+                if (s->pcrSelections[j].hash)
+                    break;
+            if (j >= s->count)
+                break;
+
+            memcpy(&s->pcrSelections[i], &s->pcrSelections[j], sizeof(s->pcrSelections[i]));
+            s->pcrSelections[j].hash = 0;
+            j++;
+        }
+    }
+
+    s->count = i;
+}
+
+static bool check_pcr_selection(listpcr_context *context) {
+
+    TPMS_CAPABILITY_DATA *cap_data = &context->cap_data;
+    TPML_PCR_SELECTION *pcr_sel = &context->pcr_selections;
+    UINT32 i, j, k;
+
+    for (i = 0; i < pcr_sel->count; i++) {
+        for (j = 0; j < cap_data->data.assignedPCR.count; j++) {
+            if (pcr_sel->pcrSelections[i].hash == cap_data->data.assignedPCR.pcrSelections[j].hash) {
+                for (k = 0; k < pcr_sel->pcrSelections[i].sizeofSelect; k++)
+                    pcr_sel->pcrSelections[i].pcrSelect[k] &= cap_data->data.assignedPCR.pcrSelections[j].pcrSelect[k];
+                break;
+            }
+        }
+
+        if (j >= cap_data->data.assignedPCR.count) {
+            const char *alg_name = get_algorithm_name(pcr_sel->pcrSelections[i].hash);
+            LOG_WARN("Ignore unsupported bank/algorithm: %s(0x%04x)\n", alg_name, pcr_sel->pcrSelections[i].hash);
+            pcr_sel->pcrSelections[i].hash = 0; //mark it as to be removed
+        }
+    }
+
+    shrink_pcr_selection(pcr_sel);
+    if (pcr_sel->count == 0)
+        return false;
+
+    return true;
+}
+
 // show all PCR banks according to g_pcrSelection & g_pcrs->
 static bool show_pcr_values(listpcr_context *context) {
 
@@ -249,7 +305,10 @@ static bool show_pcr_values(listpcr_context *context) {
     return true;
 }
 
-static bool show_selected_pcr_values(listpcr_context *context) {
+static bool show_selected_pcr_values(listpcr_context *context, bool check) {
+
+    if (check && !check_pcr_selection(context))
+        return false;
 
     if (!read_pcr_values(context))
         return false;
@@ -265,7 +324,7 @@ static bool show_all_pcr_values(listpcr_context *context) {
     if (!init_pcr_selection(0, context))
         return false;
 
-    return show_selected_pcr_values(context);
+    return show_selected_pcr_values(context, false);
 }
 
 static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id) {
@@ -273,7 +332,7 @@ static bool show_alg_pcr_values(listpcr_context *context, TPMI_ALG_HASH alg_id) 
     if (!init_pcr_selection(alg_id, context))
         return false;
 
-    return show_selected_pcr_values(context);
+    return show_selected_pcr_values(context, false);
 }
 
 static bool get_banks(listpcr_context *context) {
@@ -399,7 +458,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     } else if (g_flag) {
         success = show_alg_pcr_values(&context, selected_algorithm);
     } else if (L_flag) {
-        success = show_selected_pcr_values(&context);
+        success = show_selected_pcr_values(&context, true);
     } else {
         success = show_all_pcr_values(&context);
     }


### PR DESCRIPTION
This pull request cherry picks the following fixes from the master branch:

c2586d4116b2 ("tpm2_listpcrs: use TPM2_GetCapability to determine PCRs to read")
433a1e44f362 ("listpcrs: remove one redundant call to tpm get cap")
ada4c20d23d9 ("listpcrs: fix for unsupported/disabled alg in -L")
9466263446fb ("build: use supported comment to suppress GCC7 fallthrough warning")
5cee30cbc3da ("kdfa: allow to build with OpenSSL 1.1.x")

Plus a patch suggested by @snits that fixes the man pages generation to include information about the tabrmd TCTI. This fix is not in the master branch because doesn't apply anymore.

We have these fixes in our 2.1.0 tpm2-tools package, so it would be nice to have it in the 2.X branch and release a new minor version so we can drop them.