### PR TITLE
tpm2_createprimary: support to print the object attributes

### DIFF
--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -184,6 +184,7 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
 
     if(setup_alg())
         return -1;
+    tpm2_tool_output("ObjectAttribute: 0x%08X\n", ctx.in_public.t.publicArea.objectAttributes.val);
 
     creationPCR.count = 0;
 


### PR DESCRIPTION
This does the same as tpm2_create.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>