### PR TITLE
[V4] tpm2_create: fix RC_ATTRIBUTES error when running test_tpm2_encryptde…

### DIFF
--- a/test/system/test_helpers.sh
+++ b/test/system/test_helpers.sh
@@ -99,3 +99,18 @@ hash_alg_supported() {
         fi
     done
 }
+
+# Certain TPM 2.0 chip, e.g, Nationz Z32H320TC, and tpm2simulator referring
+# to TPM 2.0 spec rev 1.16 may have an errata, disallowing both decrypt and
+# sign set for a symcipher object, and in response to RC_ATTRIBUTES. In
+# order to work around it, we attempt to run tpm2_create again with sign bit
+# clear.
+create_object() {
+    local alg_create_obj=0x20072
+
+    if tpm2_create $@ 2>&1 | grep -q 'Create Object Failed ! ErrorCode: 0x2c2'; then
+        tpm2_create -Q -A $alg_create_obj $@
+    else
+        true
+    fi
+}

--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -57,7 +57,7 @@ tpm2_createprimary -Q -A p -g sha1 -G rsa -C context.out
 # values.
 for gAlg in `populate_hash_algs mixed`; do
     for GAlg in rsa 0x08 ecc 0x25; do
-        tpm2_create -Q -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
+        create_object -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
         cleanup keep_context
     done
 done
@@ -67,7 +67,7 @@ cleanup keep_context
 echo "f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988" \
 | xxd -r -p > policy.bin
 
-tpm2_create -Q -c context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv -E
+create_object -c context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv -E
 
 cmp -i 14:0 -n 32 key.pub policy.bin -s
 

--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source test_helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -60,7 +62,7 @@ tpm2_takeownership -Q -c
 
 tpm2_createprimary -Q -A e -g sha1 -G rsa -C primary.ctx
 
-tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -c primary.ctx
+create_object -g sha256 -G symcipher -u key.pub -r key.priv -c primary.ctx
 
 tpm2_load -Q -c primary.ctx -u key.pub -r key.priv -n key.name -C decrypt.ctx
 

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -30,6 +30,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
+
+source test_helpers.sh
+
 alg_primary_obj=sha256
 alg_primary_key=rsa
 alg_create_obj=0x000B
@@ -77,7 +80,7 @@ tpm2_takeownership -c
 
 tpm2_createprimary -Q -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -c $file_primary_key_ctx
+create_object -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -c $file_primary_key_ctx
 
 tpm2_load -Q -c $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -C $file_quote_key_ctx
 


### PR DESCRIPTION
Changelog:

- V4
  * Rebase.

- V3
  * Explicitly mentioning TPM 2.0 spec rev 1.16.
  * Place the tpm2_create wrapper to the common piece test_helpers.sh.

Note that this patch is based on the one submitted to https://github.com/01org/tpm2-tools/pull/552
 
Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>