### PR TITLE
man: specify correct long option for '-C'

### DIFF
--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -36,7 +36,7 @@ into the TPM.
   * **-n**, **--name**=_NAME\_DATA\_FILE_:
     An optional file to save the name structure of the object.
 
-  * **-C**, **--name**=_CONTEXT\_FILE_:
+  * **-C**, **--context**=_CONTEXT\_FILE_:
     An optional file to save the object context to.
 
   * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -350,7 +350,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"objectAttributes",1,NULL,'A'},
       {"inFile",1,NULL,'I'},
       {"policy-file",1,NULL,'L'},
-      {"enforce-policy",1,NULL,'E'},
+      {"enforce-policy",0,NULL,'E'},
       {"pubfile",1,NULL,'u'},
       {"privfile",1,NULL,'r'},
       {"contextParent",1,NULL,'c'},

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -196,7 +196,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
       {"item",                 required_argument, NULL, 'H'},
-      {"pwdi",                 required_argument, NULL, 'P'},
+      {"pwdk",                 required_argument, NULL, 'P'},
       {"outfile",              required_argument, NULL, 'o'},
       {"itemContext",          required_argument, NULL, 'c'},
       {"input-session-handle", required_argument, NULL, 'S'},


### PR DESCRIPTION
Manpage says '-n' and '-C' both have the long option '--name'. But
code says '-C' => '--context' and '-n' => '--name'

Signed-off-by: Satish Bysany <>