### PR TITLE
test_tpm2_create.sh,test_tpm2_createprimary.sh: test sha256 instead o…

### DIFF
--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -53,7 +53,7 @@ tpm2_createprimary -Q -A p -g sha1 -G rsa -C context.out
 
 # Keep the algorithm specifiers mixed to test friendly and raw
 # values.
-for gAlg in sha1 0x0B sha384; do
+for gAlg in sha1 0x0B sha256; do
     for GAlg in rsa 0x08 ecc 0x25; do
         tpm2_create -Q -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
         cleanup keep_context

--- a/test/system/test_tpm2_createprimary.sh
+++ b/test/system/test_tpm2_createprimary.sh
@@ -52,7 +52,7 @@ cleanup
 
 # Keep the algorithm specifiers mixed to test friendly and raw
 # values.
-for gAlg in 0x04 sha256 0x0C; do
+for gAlg in sha1 0x04 sha256; do
     for GAlg in 0x01 keyedhash ecc 0x25; do
         for Atype in o e p n; do
             tpm2_createprimary -Q -A $Atype -g $gAlg -G $GAlg -C context.out


### PR DESCRIPTION
…f sha384

sha384 is not so common on a real TPM 2.0 chip so it is better to test
sha256 instead.

Otherwise, the following failure would happen.

ObjectAttribute: 0x00060072
ERROR:
Create Object Failed ! ErrorCode: 0x2c3

tpm2_create -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv on
line 58 failed: 1

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>