### PR TITLE
nvread: fix missing 'f' in optstring

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -261,7 +261,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "input-session-handle",1,          NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
+    *opts = tpm2_options_new("x:a:f:s:o:P:S:", ARRAY_LEN(topts), topts, on_option, NULL);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
nvread is not understanding the "-f" parameter because the
option is missing from the optstring. Add it to the optstring.

Signed-off-by: Fabien Parent <fparent@baylibre.com>