### PR TITLE
test_tpm2_createpolicy.sh: fix the compare between PCR 0 and hex value

### DIFF
--- a/test/system/test_tpm2_createpolicy.sh
+++ b/test/system/test_tpm2_createpolicy.sh
@@ -54,10 +54,10 @@ do
     # This script expects PCR index 0 to be equal to 0x03
     #
     value=`tpm2_pcrlist -L $halg:0 | grep PCR_00 | cut -d\: -f 2-`
-    if [[ $value -ne 0x03 ]]; then
+    if [[ 16#$value -ne 0x03 ]]; then
         echo "Expected PCR 0 \"$halg\" bank to be 0x3, found: \"$value\"" 1>&2
         exit 1
-	fi
+    fi
 
     tpm2_createpolicy -P -L $halg:0 -f policy.out
 


### PR DESCRIPTION
This fix resolves the following errors:

./test_tpm2_createpolicy.sh: line 57: [[:
9872964b9b40cdd0363fcd6af8c267c9cb34200b: value too great for base
(error token is "9872964b9b40cdd0363fcd6af8c267c9cb34200b")
Failure: Creating Policy Digest with PCR policy for index 0 and sha1
pcr index hash

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>