### PR TITLE
test_tpm2_createpolicy.sh: use file to supply expected PCR value

### DIFF
--- a/test/system/test_tpm2_createpolicy.sh
+++ b/test/system/test_tpm2_createpolicy.sh
@@ -39,27 +39,23 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f policy.out
+    rm -f pcr.in policy.out
 }
 trap cleanup EXIT
 
+declare -A digestlengths=(["sha1"]=20 ["sha256"]=32)
 declare -A expected_policy_digest=(["sha1"]="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
                                    ["sha256"]="33e36e786c878632494217c3f490e74ca0a3a122a8a4f3c5302500df3b32b3b8")
 
-for halg in sha1 sha256
+for halg in ${!digestlengths[@]}
 do
     cleanup
 
-    #
-    # This script expects PCR index 0 to be equal to 0x03
-    #
-    value=`tpm2_pcrlist -L $halg:0 | grep PCR_00 | cut -d\: -f 2-`
-    if [[ 16#$value -ne 0x03 ]]; then
-        echo "Expected PCR 0 \"$halg\" bank to be 0x3, found: \"$value\"" 1>&2
-        exit 1
-    fi
+    # Create file containing expected PCR value
+    head -c $((${digestlengths[$halg]} - 1)) /dev/zero > pcr.in
+    echo -n -e '\x03' >> pcr.in
 
-    tpm2_createpolicy -P -L $halg:0 -f policy.out
+    tpm2_createpolicy -P -L $halg:0 -F pcr.in -f policy.out
 
     # Test the policy creation hashes against expected
     if [ $(xxd -p policy.out | tr -d '\n' ) != "${expected_policy_digest[${halg}]}" ]; then


### PR DESCRIPTION
For the simulator, PCR0 contains the value 0x03, but this is not necessarily the case for other TPM implementations. Therefore, use a file to supply the expected PCR value to tpm2_createpolicy, so that the expected policy digest remains unchanged and the test passes for all TPMs.

We tried a similar approach some time ago. I've now reimplemented it, but had no chance to test it, so I hope that this works :)

Fixes #551, #335.