### PR TITLE
test/system: remove pipe to /dev/null for rm -f calls

### DIFF
--- a/test/system/test_tpm2_activecredential.sh
+++ b/test/system/test_tpm2_activecredential.sh
@@ -38,8 +38,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f secret.data ek.pub ak.pub ak.name mkcred.out ak.out actcred.out \
-          &>/dev/null
+    rm -f secret.data ek.pub ak.pub ak.name mkcred.out ak.out actcred.out
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.

--- a/test/system/test_tpm2_akparse.sh
+++ b/test/system/test_tpm2_akparse.sh
@@ -38,7 +38,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f ak.out akparse.out ek.pub ak.pub ak.name &>/dev/null
+    rm -f ak.out akparse.out ek.pub ak.pub ak.name
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.

--- a/test/system/test_tpm2_createpolicy.sh
+++ b/test/system/test_tpm2_createpolicy.sh
@@ -39,7 +39,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f policy.out &>/dev/null
+    rm -f policy.out
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
The -f parameter already suppresses the common but harmless error messages,
e.g. file not found, so this is unnecessary.

Pointed out by @martinezjavier in #555.