### PR TITLE
Long option name fixes

### DIFF
--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -28,21 +28,21 @@ These options control the object verification:
   * **-k**, **--key-handle**=_KEY\_HANDLE_:
     The _KEY\_HANDLE_ of Loaded key used to decrypt the the random seed.
 
-  * **-C**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-C**, **--key-context**=_KEY\_CONTEXT\_FILE_:
     _KEY\_CONTEXT\_FILE_ is the path to a context file.
 
   * **-P**, **--password**=_PASSWORD_:
     Use _PASSWORD_ for providing an authorization value for the _KEY\_HANDLE_.
     Passwords should follow the "password formatting standards, see section "Password Formatting".
 
-  * **-e**, **--endorsePassword**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-password**=_ENDORSE\_PASSWORD_:
     The endorsement password, optional. Follows the same formating guidelines as the handle password option -P.
 
-  * **-f**, **--inFile**=_INPUT\_FILE_:
+  * **-f**, **--in-file**=_INPUT\_FILE_:
     Input file path, containing the two structures needed by tpm2_activatecredential function. This is created
     via the tpm2_makecredential(1) command.
 
-  * **-o**, **--outFile**=_OUTPUT\_FILE_:
+  * **-o**, **--out-file**=_OUTPUT\_FILE_:
     Output file path, record the secret to decrypt  the certificate.
 
 [common options](common/options.md)

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -24,16 +24,16 @@ An object that only has its public area loaded cannot be certified.
 
 These options control the ceritifcation:
 
-  * **-H**, **--objHandle**=_OBJECT\_HANDLE_:
+  * **-H**, **--obj-handle**=_OBJECT\_HANDLE_:
     The handle of the object to be certified.
 
-  * **-C**, **--objContext**=_FILE_:
+  * **-C**, **--obj-context**=_FILE_:
     Use _FILE_ for providing the object context.
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
     Handle of the key used to sign the attestation  structure.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT_:
     Filename of the key context used to sign the  attestation structure.
 
   * **-P**, **--pwdo**=_OBJECT\_PASSWORD_:
@@ -48,10 +48,10 @@ These options control the ceritifcation:
     Follows the same formatting guidelines as the object handle password or
     -P option.
 
-  * **-a**, **--attestFile**=_ATTEST\_FILE_:
+  * **-a**, **--attest-file**=_ATTEST\_FILE_:
     Output file name for the attestation data.
 
-  * **-s**, **--sigFile**=_SIG\_FILE_:
+  * **-s**, **--sig-file**=_SIG\_FILE_:
     Output file name for the signature data.
 
 [common options](common/options.md)

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -23,7 +23,7 @@ These options for creating the tpm entity:
   * **-H**, **--pparent**=_PARENT\_HANDLE_:
     The handle of the parent object to create this object under.
 
-  * **-c**, **--contextParent**=_PARENT\_CONTEXT\_FILE_:
+  * **-c**, **--context-parent**=_PARENT\_CONTEXT\_FILE_:
     The filename for parent context.
 
   * **-P**, **--pwdp**=_PARENT\_KEY\_PASSWORD_:
@@ -45,10 +45,10 @@ These options for creating the tpm entity:
     like -g option. See section "Supported Public Object Algorithms" for a list
     of supported object algorithms.
 
-  * **-A**, **--objectAttributes**=_ATTRIBUTES_:
+  * **-A**, **--object-attributes**=_ATTRIBUTES_:
     The object attributes, optional.
 
-  * **-I**, **--inFile**=_FILE_:
+  * **-I**, **--in-file**=_FILE_:
     The data file to be sealed, optional. If file is -, read from stdin.
     When sealing data only the TPM_ALG_KEYEDHASH algorithm is allowed.
 

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -17,10 +17,10 @@ specified symmetric key.
 
 # OPTIONS
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
     the symmetric key used for the operation (encryption/decryption).
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
     filename of the key context used for the  operation.
 
   * **-P**, **--pwdk**=_KEY\_PASSWORD_:
@@ -31,7 +31,7 @@ specified symmetric key.
   * **-D**, **--decrypt**:
     Perform a decrypt operation. Default is encryption.
 
-  * **-I**, **--inFile**=_INPUT\_FILE_:
+  * **-I**, **--in-file**=_INPUT\_FILE_:
     Input file path containing data for decrypt or encrypt operation.
 
   * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -20,13 +20,13 @@ server.
 
 # OPTIONS
 
-  * **-e**, **--endorsePasswd**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-passwd**=_ENDORSE\_PASSWORD_:
     specifies current endorse password (string, optional,default:NULL).
 
-  * **-o**, **--ownerPasswd**=_OWNER\_PASSWORD_:
+  * **-o**, **--owner-passwd**=_OWNER\_PASSWORD_:
     specifies current owner password (string, optional,default:NULL).
 
-  * **-P**, **--ekPasswd**=_EK\_PASSWORD_:
+  * **-P**, **--ek-passwd**=_EK\_PASSWORD_:
     specifies the EK password when created (string,optional,default:NULL).
 
     Passwords should follow the password formatting standards, see

--- a/man/tpm2_getpubak.1.md
+++ b/man/tpm2_getpubak.1.md
@@ -19,23 +19,23 @@ return pub AK and AK name. If any passwd option is missing, assume NULL.
 
 # OPTIONS
 
-  * **-e**, **--endorsePasswd**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-passwd**=_ENDORSE\_PASSWORD_:
     Specifies current endorsement password, defaults to NULL.
     Passwords should follow the "password formatting standards, see section
     "Password Formatting".
 
-  * **-P**, **--akPasswd**=_AK\_PASSWORD_
+  * **-P**, **--ak-passwd**=_AK\_PASSWORD_
     Specifies the AK password when created, defaults to NULL.
     Same formatting as the endorse password value or -e option.
 
-  * **-o**, **--ownerPasswd**=_OWNER\_PASSWORD_
+  * **-o**, **--owner-passwd**=_OWNER\_PASSWORD_
     Specifies the current owner password, defaults to NULL.
     Same formatting as the endorse password value or -e option.
 
-  * **-E**, **--ekHandle**=_EK\_HANDLE_:
+  * **-E**, **--ek-handle**=_EK\_HANDLE_:
     Specifies the handle used to make EK persistent.
 
-  * **-k**, **--akHandle**=_AK\_HANDLE_:
+  * **-k**, **--ak-handle**=_AK\_HANDLE_:
     Specifies the handle used to make AK persistent.
 
   * **-g**, **--alg**=_ALGORITHM_:
@@ -53,7 +53,7 @@ return pub AK and AK name. If any passwd option is missing, assume NULL.
     binary data structure corresponding to the TPM2B_PUBLIC struct in the
     specification.
 
-  * **-n**, **--akName**=_NAME_:
+  * **-n**, **--ak-name**=_NAME_:
     Specifies the file used to save the ak name.
 
 [common options](common/options.md)

--- a/man/tpm2_getpubek.1.md
+++ b/man/tpm2_getpubek.1.md
@@ -21,12 +21,12 @@ Refer to:
 
 # OPTIONS
 
-  * **-e**, **--endorsePasswd**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-passwd**=_ENDORSE\_PASSWORD_:
     Specifies current endorsement password, defaults to NULL.
     Passwords should follow the "password formatting standards, see section
     "Password Formatting".
 
-  * **-o**, **--ownerPasswd**=_OWNER\_PASSWORD_
+  * **-o**, **--owner-passwd**=_OWNER\_PASSWORD_
     Specifies the current owner password, defaults to NULL.
     Same formatting as the endorse password value or -e option.
 

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -17,10 +17,10 @@ _FILE_ is not specified, then data is read from stdin.
 
 # OPTIONS
 
- * **-k**, **--keyHandle**=_KEY\_CONTEXT\_FILE_:
+ * **-k**, **--key-handle**=_KEY\_CONTEXT\_FILE_:
     The key handle for the symmetric signing key providing the HMAC key.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
     The filename of the key context used for the operation.
 
   * **-P**, **--pwdk**=_KEY\_PASSWORD_:

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -20,7 +20,7 @@ into the TPM.
   * **-H**, **--parent**=_PARENT\_HANDLE_:
     The handle of the parent object. Either this option or **-c** must be used.
 
-  * **-c**, **--contextParent**=_PARENT\_CONTEXT\_FILE_:
+  * **-c**, **--context-parent**=_PARENT\_CONTEXT\_FILE_:
     The filename for parent context.
 
   * **-P**, **--pwdp**=_PARENT\_KEY\_PASSWORD_:

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -27,7 +27,7 @@ to encrypt the AK certififcate.
   * **-n**, **--name**=_NAME_
     The name of the key for which certificate is to be created.
 
-  * **-o**, **--outFile**=_OUT\_FILE_
+  * **-o**, **--out-file**=_OUT\_FILE_
     The output file path, recording the two structures output by
     tpm2_makecredential function.
 

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -19,7 +19,7 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--authHandle**=_SECRET\_DATA\_FILE_:
+  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
@@ -32,11 +32,11 @@
     entitiy. Either the raw bitfield mask or "nice-names" may be used. See
     section "NV Attributes" for more details.
 
-  * **-P**, **--handlePasswd**=_HANDLE\_PASSWORD_:
+  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 
-  * **-I**, **--indexPasswd**=_INDEX\_PASSWORD_:
+  * **-I**, **--index-passwd**=_INDEX\_PASSWORD_:
     specifies the password of NV Index when created. Follows the same formatting
     guidelines as the handle password or -P option.
 

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -19,7 +19,7 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--authHandle**=_SECRET\_DATA\_FILE_:
+  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
@@ -27,7 +27,7 @@
   * **-f**, **--output**=_FILE_:
     file to write data
 
-  * **-P**, **--handlePasswd**=_HANDLE\_PASSWORD_:
+  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -20,12 +20,12 @@ is released on subsequent restart of the machine.
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--authHandle**=_SECRET\_DATA\_FILE_:
+  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
 
-  * **-P**, **--handlePasswd**=_HANDLE\_PASSWORD_:
+  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -20,7 +20,7 @@ defined with tpm2_nvdefine(1).
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to release.
 
-  * **-a**, **--authHandle**=_SECRET\_DATA\_FILE_:
+  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
@@ -28,7 +28,7 @@ defined with tpm2_nvdefine(1).
   * **-s**, **--size**=_SIZE_:
     specifies the size of data area in bytes.
 
-  * **-P**, **--handlePasswd**=_HANDLE\_PASSWORD_:
+  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -19,12 +19,12 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--authHandle**=_SECRET\_DATA\_FILE_:
+  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
 
-  * **-P**, **--handlePasswd**=_HANDLE\_PASSWORD_:
+  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
     "password formatting standards, see section "Password Formatting".
 

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -23,7 +23,7 @@
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-L**, **--selList**=_PCR\_SELECTION\_LIST_:
+  * **-L**, **--sel-list**=_PCR\_SELECTION\_LIST_:
 
     The list of pcr banks and selected PCRs' ids for each bank to display.
     _PCR\_SELECTION\_LIST_ values should follow the

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -16,30 +16,30 @@
 
 # OPTIONS
 
-  * **-k**, **--akHandle**=_AK\_HANDLE_:
+  * **-k**, **--ak-handle**=_AK\_HANDLE_:
 
     Handle of existing AK.
 
-  * **-c**, **--akContext**=_AK\_CONTEXT\_FILE_:
+  * **-c**, **--ak-context**=_AK\_CONTEXT\_FILE_:
 
     Filename for the existing AK's context.
 
-  * **-P**, **--akPassword**=_AK\_PASSWORD_:
+  * **-P**, **--ak-password**=_AK\_PASSWORD_:
 
     specifies the password of _AK\_HANDLE_. Passwords should follow the
     password formatting standards, see section "Password Formatting".
 
-  * **-l**, **--idList**=_PCR\_ID\_LIST_
+  * **-l**, **--id-list**=_PCR\_ID\_LIST_
 	
 	The comma separated list of selected PCRs' ids, 0~23 e.g. "4,5,6".
 
-  * **-L**, **--selList**=_PCR\_SELECTION\_LIST_:
+  * **-L**, **--sel-list**=_PCR\_SELECTION\_LIST_:
 
     The list of pcr banks and selected PCRs' ids for each bank.
     _PCR\_SELECTION\_LIST_ values should follow the
     pcr bank specifiers standards, see section "PCR Bank Specfiers".
 
-  * **-o**, **--outFile**:
+  * **-o**, **--out-file**:
 
     Output file path, recording the two structures output by tpm2_quote function.
 
@@ -50,7 +50,7 @@
 
 [signature options](common/signature.md)
 
-  * **-q**, **--qualifyData**:
+  * **-q**, **--qualify-data**:
 
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -20,7 +20,7 @@
 
     The loaded object handle to read the public data of.
 
-  * **-c**, **--akContext**=_OBJECT\_CONTEXT\_FILE_:
+  * **-c**, **--ak-context**=_OBJECT\_CONTEXT\_FILE_:
 
     Filename for object context.
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -22,11 +22,11 @@ The key referenced by keyHandle is **required** to be:
 
 # OPTIONS
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
 
     the public portion of RSA key to use for decryption.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
 
     filename of the key context used for the operation.
 
@@ -35,11 +35,11 @@ The key referenced by keyHandle is **required** to be:
     specifies the password of _KEY\_HANDLE_. Passwords should follow the
     password formatting standards, see section "Password Formatting".
 
-  * **-I**, **--inFile**=_INPUT\FILE_:
+  * **-I**, **--in-file**=_INPUT\FILE_:
 
     Input file path, containing the data to be decrypted.
 
-  * **-o**, **--outFile**=_OUTPUT\_FILE_:
+  * **-o**, **--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data.
 

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -22,11 +22,11 @@ The key referenced by keyHandle is **required** to be:
 
 # OPTIONS
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
 
     the public portion of RSA key to use for encryption.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
 
     filename of the key context used for the operation.
 
@@ -35,11 +35,11 @@ The key referenced by keyHandle is **required** to be:
     specifies the password of _KEY\_HANDLE_. Passwords should follow the
     password formatting standards, see section "Password Formatting".
 
-  * **-I**, **--inFile**=_INPUT\FILE_:
+  * **-I**, **--in-file**=_INPUT\FILE_:
 
     Input file path, containing the data to be encrypted.
 
-  * **-o**, **--outFile**=_OUTPUT\_FILE_:
+  * **-o**, **--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data.
 

--- a/man/tpm2_send_command.1.md
+++ b/man/tpm2_send_command.1.md
@@ -26,7 +26,7 @@ program to decode and display the response in a human readable form.
 
     Input file to read a command buffer from. Defaults to stdin.
 
-  * **-o**, **--outFile**=_OUTPUT\_FILE_:
+  * **-o**, **--out-file**=_OUTPUT\_FILE_:
 
     Output file to send response buffer to. Defaults to stdout.
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -20,11 +20,11 @@ data and validation shall indicate that hashed data did not start with
 
 # OPTIONS
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
 
     Handle of key that will perform signing.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
 
     Filename of the key context used for the operation.
 

--- a/man/tpm2_takeownership.1.md
+++ b/man/tpm2_takeownership.1.md
@@ -21,35 +21,35 @@ sign.
 
 # OPTIONS
 
-  * **-o**, **--ownerPassword**=_OWNER\_PASSWORD_:
+  * **-o**, **--owner-password**=_OWNER\_PASSWORD_:
     The new owner authorization value.
 
     Passwords should follow the password formatting standards, see section
     "Password Formatting".
 
-  * **-e**, **--endorsePassword**=_ENDORSE\_PASSWORD_:
+  * **-e**, **--endorse-password**=_ENDORSE\_PASSWORD_:
 
     The new endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-l**, **--lockoutPassword**=_LOCKOUT\_PASSWORD_:
+  * **-l**, **--lockout-password**=_LOCKOUT\_PASSWORD_:
 
     The new lockout authorization value.
 
     The new endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-O**, **--oldOwnerPassword**=_OLD\_OWNER\_PASSWORD_:
+  * **-O**, **--old-ownerPassword**=_OLD\_OWNER\_PASSWORD_:
 
     The old owner authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-E**, **--oldEndorsePassword**=_OLD\_ENDORSE\_PASSWORD_:
+  * **-E**, **--old-endorsePassword**=_OLD\_ENDORSE\_PASSWORD_:
 
     The old endorse authorization value. Passwords should follow the same
     formatting requirements as the -o option.
 
-  * **-L**, **--oldLockoutPassword**=_OLD\_LOCKOUT\_PASSWORD_:
+  * **-L**, **--old-lockoutPassword**=_OLD\_LOCKOUT\_PASSWORD_:
 
     The old lockout authorization value. Passwords should follow the same
     formatting requirements as the -o option.

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -29,7 +29,7 @@ session using the **--input-session-handle** option.
 
     Item handle of loaded object.
 
-  * **-c**, **--itemContext**=_ITEM\_CONTEXT\_FILE_:
+  * **-c**, **--item-context**=_ITEM\_CONTEXT\_FILE_:
 
     Filename of the item context.
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -21,11 +21,11 @@ symmetric key, both the public and private portions need to be loaded.
 
 # OPTIONS
 
-  * **-k**, **--keyHandle**=_KEY\_HANDLE_:
+  * **-k**, **--key-handle**=_KEY\_HANDLE_:
 
     Handle of key that will used in the validation.
 
-  * **-c**, **--keyContext**=_KEY\_CONTEXT\_FILE_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT\_FILE_:
 
     Filename of the key context used for the operation.
 

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -283,12 +283,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
          {"handle",        required_argument, NULL, 'H'},
          {"context",       required_argument, NULL, 'c'},
-         {"keyHandle",     required_argument, NULL, 'k'},
-         {"keyContext",    required_argument, NULL, 'C'},
+         {"key-handle",     required_argument, NULL, 'k'},
+         {"key-context",    required_argument, NULL, 'C'},
          {"Password",      required_argument, NULL, 'P'},
-         {"endorsePasswd", required_argument, NULL, 'e'},
-         {"inFile",        required_argument, NULL, 'f'},
-         {"outFile",       required_argument, NULL, 'o'},
+         {"endorse-passwd", required_argument, NULL, 'e'},
+         {"in-file",        required_argument, NULL, 'f'},
+         {"out-file",       required_argument, NULL, 'o'},
          {"passwdInHex",   no_argument,       NULL, 'X'},
     };
 

--- a/tools/tpm2_akparse.c
+++ b/tools/tpm2_akparse.c
@@ -158,7 +158,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
             { "file",    required_argument, NULL, 'f' },
-            { "keyFile", required_argument, NULL, 'k' },
+            { "key-file", required_argument, NULL, 'k' },
     };
 
     *opts = tpm2_options_new("f:k:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -291,15 +291,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"objectHandle", required_argument, NULL, 'H'},
-      {"keyHandle",    required_argument, NULL, 'k'},
+      {"object-handle", required_argument, NULL, 'H'},
+      {"key-handle",    required_argument, NULL, 'k'},
       {"pwdo",         required_argument, NULL, 'P'},
       {"pwdk",         required_argument, NULL, 'K'},
       {"halg",         required_argument, NULL, 'g'},
-      {"attestFile",   required_argument, NULL, 'a'},
-      {"sigFile",      required_argument, NULL, 's'},
-      {"objContext",   required_argument, NULL, 'C'},
-      {"keyContext",   required_argument, NULL, 'c'},
+      {"attest-file",   required_argument, NULL, 'a'},
+      {"sig-file",      required_argument, NULL, 's'},
+      {"obj-context",   required_argument, NULL, 'C'},
+      {"key-context",   required_argument, NULL, 'c'},
       {NULL,           no_argument,       NULL, '\0'}
     };
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -347,13 +347,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"pwdk",1,NULL,'K'},
       {"halg",1,NULL,'g'},
       {"kalg",1,NULL,'G'},
-      {"objectAttributes",1,NULL,'A'},
-      {"inFile",1,NULL,'I'},
+      {"object-attributes",1,NULL,'A'},
+      {"in-file",1,NULL,'I'},
       {"policy-file",1,NULL,'L'},
       {"enforce-policy",0,NULL,'E'},
       {"pubfile",1,NULL,'u'},
       {"privfile",1,NULL,'r'},
-      {"contextParent",1,NULL,'c'},
+      {"context-parent",1,NULL,'c'},
       {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -183,12 +183,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        {"keyHandle",   required_argument, NULL, 'k'},
+        {"key-handle",   required_argument, NULL, 'k'},
         {"pwdk",        required_argument, NULL, 'P'},
         {"decrypt",     required_argument, NULL, 'D'},
-        {"inFile",      required_argument, NULL, 'I'},
-        {"outFile",     required_argument, NULL, 'o'},
-        {"keyContext",  required_argument, NULL, 'c'},
+        {"in-file",      required_argument, NULL, 'I'},
+        {"out-file",     required_argument, NULL, 'o'},
+        {"key-context",  required_argument, NULL, 'c'},
         {"input-session-handle",1,         NULL, 'S'},
         {NULL,          no_argument,       NULL, '\0'}
     };

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -547,10 +547,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] =
     {
-        { "endorsePasswd", 1, NULL, 'e' },
-        { "ownerPasswd"  , 1, NULL, 'o' },
+        { "endorse-passwd", 1, NULL, 'e' },
+        { "owner-passwd"  , 1, NULL, 'o' },
         { "handle"       , 1, NULL, 'H' },
-        { "ekPasswd"     , 1, NULL, 'P' },
+        { "ek-passwd"     , 1, NULL, 'P' },
         { "alg"          , 1, NULL, 'g' },
         { "file"         , 1, NULL, 'f' },
         { "NonPersistent", 0, NULL, 'N' },

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -472,16 +472,16 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "ownerPasswd", required_argument, NULL, 'o' },
-        { "endorsePasswd", required_argument, NULL, 'e' },
-        { "ekHandle"   , required_argument, NULL, 'E' },
-        { "akHandle"   , required_argument, NULL, 'k' },
+        { "owner-passwd", required_argument, NULL, 'o' },
+        { "endorse-passwd", required_argument, NULL, 'e' },
+        { "ek-handle"   , required_argument, NULL, 'E' },
+        { "ak-handle"   , required_argument, NULL, 'k' },
         { "alg"        , required_argument, NULL, 'g' },
-        { "digestAlg"  , required_argument, NULL, 'D' },
-        { "signAlg"    , required_argument, NULL, 's' },
-        { "akPasswd"   , required_argument, NULL, 'P' },
+        { "digest-alg"  , required_argument, NULL, 'D' },
+        { "sign-alg"    , required_argument, NULL, 's' },
+        { "ak-passwd"   , required_argument, NULL, 'P' },
         { "file"       , required_argument, NULL, 'f' },
-        { "akName"     , required_argument, NULL, 'n' },
+        { "ak-name"     , required_argument, NULL, 'n' },
     };
 
     *opts = tpm2_options_new("o:E:e:k:g:D:s:P:f:n:p:", ARRAY_LEN(topts), topts, on_option, NULL);

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -311,10 +311,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "endorsePasswd", required_argument, NULL, 'e' },
-        { "ownerPasswd"  , required_argument, NULL, 'o' },
+        { "endorse-passwd", required_argument, NULL, 'e' },
+        { "owner-passwd"  , required_argument, NULL, 'o' },
         { "handle"       , required_argument, NULL, 'H' },
-        { "ekPasswd"     , required_argument, NULL, 'P' },
+        { "ek-passwd"     , required_argument, NULL, 'P' },
         { "alg"          , required_argument, NULL, 'g' },
         { "file"         , required_argument, NULL, 'f' },
         {"input-session-handle",1,            NULL, 'S' },

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -281,8 +281,8 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        {"keyHandle",   required_argument, NULL, 'k'},
-        {"keyContext",  required_argument, NULL, 'c'},
+        {"key-handle",   required_argument, NULL, 'k'},
+        {"key-context",  required_argument, NULL, 'c'},
         {"pwdk",        required_argument, NULL, 'P'},
         {"algorithm",   required_argument, NULL, 'g'},
         {"outfile",     required_argument, NULL, 'o'},

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -194,7 +194,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"privfile",1,NULL,'r'},
       {"name",1,NULL,'n'},
       {"context",1,NULL,'C'},
-      {"contextParent",1,NULL,'c'},
+      {"context-parent",1,NULL,'c'},
       {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -181,10 +181,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"encKey"  ,required_argument, NULL, 'e'},
+      {"enc-key"  ,required_argument, NULL, 'e'},
       {"sec"     ,required_argument, NULL, 's'},
       {"name"    ,required_argument, NULL, 'n'},
-      {"outFile" ,required_argument, NULL, 'o'},
+      {"out-file" ,required_argument, NULL, 'o'},
       {NULL      ,no_argument      , NULL, '\0'}
     };
 

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -198,11 +198,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                  required_argument,  NULL,   'x' },
-        { "authHandle",             required_argument,  NULL,   'a' },
+        { "auth-handle",             required_argument,  NULL,   'a' },
         { "size",                   required_argument,  NULL,   's' },
         { "attribute",              required_argument,  NULL,   't' },
-        { "handlePasswd",           required_argument,  NULL,   'P' },
-        { "indexPasswd",            required_argument,  NULL,   'I' },
+        { "handle-passwd",           required_argument,  NULL,   'P' },
+        { "index-passwd",            required_argument,  NULL,   'I' },
         { "passwdInHex",            no_argument,        NULL,   'X' },
         { "policy-file",            required_argument,  NULL,   'L' },
         { "input-session-handle",   required_argument,  NULL,   'S' },

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -253,11 +253,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
-        { "authHandle"  , required_argument, NULL, 'a' },
+        { "auth-handle"  , required_argument, NULL, 'a' },
         { "output"      , required_argument, NULL, 'f' },
         { "size"        , required_argument, NULL, 's' },
         { "offset"      , required_argument, NULL, 'o' },
-        { "handlePasswd", required_argument, NULL, 'P' },
+        { "handle-passwd", required_argument, NULL, 'P' },
         { "input-session-handle",1,          NULL, 'S' },
     };
 

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -142,8 +142,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
-        { "authHandle"  , required_argument, NULL, 'a' },
-        { "handlePasswd", required_argument, NULL, 'P' },
+        { "auth-handle"  , required_argument, NULL, 'a' },
+        { "handle-passwd", required_argument, NULL, 'P' },
         { "passwdInHex" , no_argument,       NULL, 'X' },
         { "input-session-handle",1,          NULL, 'S' },
     };

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -130,8 +130,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
-        { "authHandle"  , required_argument, NULL, 'a' },
-        { "handlePasswd", required_argument, NULL, 'P' },
+        { "auth-handle"  , required_argument, NULL, 'a' },
+        { "handle-passwd", required_argument, NULL, 'P' },
         { "input-session-handle",1,          NULL, 'S' },
     };
 

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -168,9 +168,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index"       , required_argument, NULL, 'x' },
-        { "authHandle"  , required_argument, NULL, 'a' },
+        { "auth-handle"  , required_argument, NULL, 'a' },
         { "file"        , required_argument, NULL, 'f' },
-        { "handlePasswd", required_argument, NULL, 'P' },
+        { "handle-passwd", required_argument, NULL, 'P' },
         { "input-session-handle",1,          NULL, 'S' },
     };
 

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -435,7 +435,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          { "algorithm", required_argument, NULL, 'g' },
          { "output",    required_argument, NULL, 'o' },
          { "algs",      no_argument,       NULL, 's' },
-         { "selList",   required_argument, NULL, 'L' },
+         { "sel-list",   required_argument, NULL, 'L' },
          { "format",    required_argument, NULL, 'f' },
      };
 

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -407,14 +407,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "akHandle",             required_argument, NULL, 'k' },
-        { "akContext",            required_argument, NULL, 'c' },
-        { "akPassword",           required_argument, NULL, 'P' },
-        { "idList",               required_argument, NULL, 'l' },
+        { "ak-handle",             required_argument, NULL, 'k' },
+        { "ak-context",            required_argument, NULL, 'c' },
+        { "ak-password",           required_argument, NULL, 'P' },
+        { "id-list",               required_argument, NULL, 'l' },
         { "algorithm",            required_argument, NULL, 'g' },
-        { "selList",              required_argument, NULL, 'L' },
-        { "outFile",              required_argument, NULL, 'o' },
-        { "qualifyData",          required_argument, NULL, 'q' },
+        { "sel-list",              required_argument, NULL, 'L' },
+        { "out-file",              required_argument, NULL, 'o' },
+        { "qualify-data",          required_argument, NULL, 'q' },
         { "input-session-handle", required_argument, NULL, 'S' },
         { "signature",            required_argument, NULL, 's' },
         { "message",              required_argument, NULL, 'm' },

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -136,7 +136,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
         { "object",        required_argument, NULL,'H' },
         { "opu",           required_argument, NULL,'o' },
-        { "contextObject", required_argument, NULL,'c' },
+        { "context-object", required_argument, NULL,'c' },
         { "format",        required_argument, NULL,'f' }
     };
 

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -158,11 +158,11 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "keyHandle",   required_argument, NULL, 'k'},
+      { "key-handle",   required_argument, NULL, 'k'},
       { "pwdk",        required_argument, NULL, 'P'},
-      { "inFile",      required_argument, NULL, 'I'},
-      { "outFile",     required_argument, NULL, 'o'},
-      { "keyContext",  required_argument, NULL, 'c'},
+      { "in-file",      required_argument, NULL, 'I'},
+      { "out-file",     required_argument, NULL, 'o'},
+      { "key-context",  required_argument, NULL, 'c'},
       { "input-session-handle",1,         NULL, 'S' },
     };
 

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -133,10 +133,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      {"keyHandle",  required_argument, NULL, 'k'},
-      {"inFile",     required_argument, NULL, 'I'},
-      {"outFile",    required_argument, NULL, 'o'},
-      {"keyContext", required_argument, NULL, 'c'},
+      {"key-handle",  required_argument, NULL, 'k'},
+      {"in-file",     required_argument, NULL, 'I'},
+      {"out-file",    required_argument, NULL, 'o'},
+      {"key-context", required_argument, NULL, 'c'},
     };
 
     *opts = tpm2_options_new("k:I:o:c:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -323,13 +323,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      {"keyHandle",            required_argument, NULL, 'k'},
+      {"key-handle",            required_argument, NULL, 'k'},
       {"pwdk",                 required_argument, NULL, 'P'},
       {"halg",                 required_argument, NULL, 'g'},
       {"msg",                  required_argument, NULL, 'm'},
       {"sig",                  required_argument, NULL, 's'},
       {"ticket",               required_argument, NULL, 't'},
-      {"keyContext",           required_argument, NULL, 'c'},
+      {"key-context",           required_argument, NULL, 'c'},
       {"input-session-handle", required_argument, NULL, 'S'},
       {"format",               required_argument, NULL, 'f'}
     };

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -194,9 +194,9 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     struct option topts[] = {
-        { "ownerPasswd",      required_argument, NULL, 'o' },
-        {"endorsePasswd",     required_argument, NULL, 'e' },
-        { "lockPasswd",       required_argument, NULL, 'l' },
+        { "owner-passwd",      required_argument, NULL, 'o' },
+        {"endorse-passwd",     required_argument, NULL, 'e' },
+        { "lock-passwd",       required_argument, NULL, 'l' },
         { "oldOwnerPasswd",   required_argument, NULL, 'O' },
         { "oldEndorsePasswd", required_argument, NULL, 'E' },
         { "oldLockPasswd",    required_argument, NULL, 'L' },

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -198,7 +198,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {"item",                 required_argument, NULL, 'H'},
       {"pwdk",                 required_argument, NULL, 'P'},
       {"outfile",              required_argument, NULL, 'o'},
-      {"itemContext",          required_argument, NULL, 'c'},
+      {"item-context",          required_argument, NULL, 'c'},
       {"input-session-handle", required_argument, NULL, 'S'},
       {"set-list",             required_argument, NULL, 'L' },
       {"pcr-input-file",       required_argument, NULL, 'F' },

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -289,14 +289,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-            { "keyHandle",  1, NULL, 'k' },
+            { "key-handle",  1, NULL, 'k' },
             { "digest",     1, NULL, 'D' },
             { "halg",       1, NULL, 'g' },
             { "msg",        1, NULL, 'm' },
             { "raw",        0, NULL, 'r' },
             { "sig",        1, NULL, 's' },
             { "ticket",     1, NULL, 't' },
-            { "keyContext", 1, NULL, 'c' },
+            { "key-context", 1, NULL, 'c' },
     };
 
 


### PR DESCRIPTION
Through some crafty python and regexe strings, I changed everything like `--fooBar` to `--foo-bar`.