### PR TITLE
tpm2_import: fix build error with OpenSSL 1.1.0 and other issues

### DIFF
--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -148,19 +148,19 @@ static bool encrypt_seed_with_tpm2_rsa_public_key(void) {
     return_code = BN_set_word(bne, RSA_F4);
     if (return_code != 1) {
         LOG_ERR("BN_set_word failed\n");
-        return 1;
+        return false;
     }
     rsa = RSA_new();
     return_code = RSA_generate_key_ex(rsa, 2048, bne, NULL);
     if (return_code != 1) {
         LOG_ERR("RSA_generate_key_ex failed\n");
-        return 1;
+        return false;
     }
     BIGNUM *n = BN_bin2bn(pub_modulus, MAX_RSA_KEY_BYTES, NULL);
     ssl_RSA_set0_key(rsa, n, NULL, NULL);
     if (n == NULL) {
         LOG_ERR("Failed RSA_set0_key\n");
-        return 1;
+        return false;
     }
     // Encrypting
     return_code = RSA_public_encrypt(MAX_RSA_KEY_BYTES, encoded,

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -145,12 +145,21 @@ static bool encrypt_seed_with_tpm2_rsa_public_key(void) {
         return false;
     }
     BIGNUM* bne = BN_new();
+    if (!bne) {
+        LOG_ERR("BN_new for bne failed\n");
+        return false;
+    }
     return_code = BN_set_word(bne, RSA_F4);
     if (return_code != 1) {
         LOG_ERR("BN_set_word failed\n");
         return false;
     }
     rsa = RSA_new();
+    if (!rsa) {
+        LOG_ERR("RSA_new failed\n");
+        BN_free(bne);
+        return false;
+    }
     return_code = RSA_generate_key_ex(rsa, 2048, bne, NULL);
     if (return_code != 1) {
         LOG_ERR("RSA_generate_key_ex failed\n");

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -161,6 +161,7 @@ static bool encrypt_seed_with_tpm2_rsa_public_key(void) {
         return false;
     }
     return_code = RSA_generate_key_ex(rsa, 2048, bne, NULL);
+    BN_free(bne);
     if (return_code != 1) {
         LOG_ERR("RSA_generate_key_ex failed\n");
         return false;
@@ -178,7 +179,6 @@ static bool encrypt_seed_with_tpm2_rsa_public_key(void) {
         LOG_ERR("Failed RSA_public_encrypt\n");
     }
     RSA_free(rsa);
-    BN_free(bne);
     return true;
 }
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -157,11 +157,11 @@ static bool encrypt_seed_with_tpm2_rsa_public_key(void) {
         return false;
     }
     BIGNUM *n = BN_bin2bn(pub_modulus, MAX_RSA_KEY_BYTES, NULL);
-    ssl_RSA_set0_key(rsa, n, NULL, NULL);
     if (n == NULL) {
-        LOG_ERR("Failed RSA_set0_key\n");
+        LOG_ERR("BN_bin2bn failed\n");
         return false;
     }
+    ssl_RSA_set0_key(rsa, n, NULL, NULL);
     // Encrypting
     return_code = RSA_public_encrypt(MAX_RSA_KEY_BYTES, encoded,
             ctx.encrypted_protection_seed_data, rsa, RSA_NO_PADDING);


### PR DESCRIPTION
This pull request contains fixes for the tpm2_import tool. I noticed these while fixing a build error with OpenSSL 1.1.0.

@idesai could you please review these since you are the author of the tpm2_import tool.

@mgerstner I would really appreciate your review too, specially for the OpenSSL API usage.