### PR TITLE
test_tpm2_create.sh,test_tpm2_createpolicy.sh: test owner instead of …

### DIFF
--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -51,7 +51,7 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_createprimary -Q -A p -g sha1 -G rsa -C context.out
+tpm2_createprimary -Q -A o -g sha1 -G rsa -C context.out
 
 # Keep the algorithm specifiers mixed to test friendly and raw
 # values.

--- a/test/system/test_tpm2_createprimary.sh
+++ b/test/system/test_tpm2_createprimary.sh
@@ -56,7 +56,7 @@ cleanup
 # values.
 for gAlg in `populate_hash_algs mixed`; do
     for GAlg in 0x01 keyedhash ecc 0x25; do
-        for Atype in o e p n; do
+        for Atype in o e n; do
             tpm2_createprimary -Q -A $Atype -g $gAlg -G $GAlg -C context.out
             cleanup keep_context
         done


### PR DESCRIPTION
…platform hierarchy

This commit resolves the following error with a real TPM hardware.
ERROR:
CreatePrimary Failed ! ErrorCode: 0x9a2

tpm2_createprimary -Q -A p -g sha1 -G rsa -C context.out on line 54
failed: 1

Usually, the platform hierarchy is locked on a real hardware. In order
to make the test more compatible, just test owner hierarchy instead of
platform hierarchy.

This change partially resolves the issue #335 (Make sure that all tests
work on a real TPM hardware) for helping on it regard.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>