### PR TITLE
lib: clean up potential memory leak

### DIFF
--- a/lib/context-util.c
+++ b/lib/context-util.c
@@ -205,8 +205,10 @@ sapi_init_from_options (common_opts_t *options)
     if (tcti_ctx == NULL)
         return NULL;
     sapi_ctx = sapi_ctx_init (tcti_ctx);
-    if (sapi_ctx == NULL)
+    if (sapi_ctx == NULL) {
+        free (tcti_ctx);
         return NULL;
+    }
     return sapi_ctx;
 }
 /*


### PR DESCRIPTION
In case where sapi_ctx_init fails in sapi_init_from_options, free tcti_ctx.

This is specific to the 2.X branch.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>