### PR TITLE
test_tpm2_import: work around spec errata

### DIFF
--- a/test/system/test_helpers.sh
+++ b/test/system/test_helpers.sh
@@ -114,3 +114,13 @@ create_object() {
         true
     fi
 }
+
+import_object() {
+    local alg_import_obj=0x20040
+
+    if tpm2_import $@ 2>&1 | grep -q 'ERROR: Failed Key Import 000002C2'; then
+        tpm2_import -A $alg_import_obj $@
+    else
+        true
+    fi
+}

--- a/test/system/test_tpm2_import.sh
+++ b/test/system/test_tpm2_import.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source test_helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -38,7 +40,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    tpm2_evictcontrol -Q -A o -H 0x81010005 -S 0x81010005 2>/dev/null
+    tpm2_evictcontrol -A o -H 0x81010005 -S 0x81010005 2>/dev/null
     rm -f import_key.ctx  import_key.name  import_key.priv  import_key.pub \
           parent.ctx parent.pub  plain.dec.ssl  plain.enc  plain.txt  sym.key
 }
@@ -46,17 +48,17 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_createprimary -Q -G 1 -g 0xb -A o -C parent.ctx
-tpm2_evictcontrol -Q -A o -c parent.ctx -S 0x81010005
+tpm2_createprimary -G 1 -g 0xb -A o -C parent.ctx
+tpm2_evictcontrol -A o -c parent.ctx -S 0x81010005
 
-dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
+dd if=/dev/urandom of=sym.key bs=1 count=16
 
-tpm2_readpublic -Q -H 0x81010005 --opu parent.pub
+tpm2_readpublic -H 0x81010005 --opu parent.pub
 
-tpm2_import -Q -k sym.key -H 0x81010005 -f parent.pub -q import_key.pub \
+import_object -k sym.key -H 0x81010005 -f parent.pub -q import_key.pub \
 -r import_key.priv
 
-tpm2_load -Q -H 0x81010005 -u import_key.pub -r import_key.priv -n import_key.name \
+tpm2_load  -H 0x81010005 -u import_key.pub -r import_key.priv -n import_key.name \
 -C import_key.ctx
 
 echo "plaintext" > "plain.txt"


### PR DESCRIPTION
TPM 2.0 spec 1.16 errata on decrypt and sign set for a symcipher.

Certain TPM 2.0 chip, e.g, Nationz Z32H320TC, and tpm2simulator
referring to TPM 2.0 spec 1.16 may have an errata, disallowing both
decrypt and sign set for a symcipher object, and in response to
RC_ATTRIBUTES.

In order to work around it, we attempt to run tpm2_importe again with
sign bit clear.

This change partially resolves the issue #335 (Make sure that all
tests work on a real TPM hardware) for helping on it regard.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>