### PR TITLE
[REVERTME] travis: get build working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
     - popd && popd
     - git clone https://github.com/01org/TPM2.0-TSS.git
     - pushd TPM2.0-TSS
+    - git checkout 65a40b4c
     - ./bootstrap && ./configure && make -j$(nproc)
     - sudo ../.ci/travis-tss-install.sh
     - popd


### PR DESCRIPTION
commit c54e876b906361984bf7e6d65e1b28525fcac425
in the tss introduces a regression in the tools.

The marshaling routine is expecting a non-null src
buffer, and using an empty src buffer results in
more invalid issues.

For now, while we trouble shoot, freeze the tss on this
commit.

Signed-off-by: William Roberts <william.c.roberts@intel.com>