### PR TITLE
travis: run tests against tpm974

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ before_install:
     - pip install --user cpp-coveralls pyyaml
 
 install: 
-    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
-    - sha256sum ibmtpm532.tar | grep -q abc0b420257917ccb42a9750588565d5e84a2b4e99a6f9f46c3dad1f9912864f
-    - mkdir ibmtpm532 && pushd ibmtpm532 && tar xzf ../ibmtpm532.tar && pushd ./src && make
+    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz
+    - sha256sum ibmtpm974.tar.gz | grep -q 8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
+    - mkdir ibmtpm974 && pushd ibmtpm974 && tar -xazf ../ibmtpm974.tar.gz && pushd ./src && make
     - ./tpm_server &
     - popd && popd
     - git clone https://github.com/01org/TPM2.0-TSS.git


### PR DESCRIPTION
Run the ci tests against the lates software tpm simulator,
version 974.

Fixes: #469

Signed-off-by: William Roberts <william.c.roberts@intel.com>