### PR TITLE
[V4] tpm2_errata: implement a generic handling for errata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,8 @@ lib_libcommon_a_SOURCES = \
     lib/rc-decode.h \
     lib/tpm2_alg_util.c \
     lib/tpm2_alg_util.h \
+    lib/tpm2_errata.c \
+    lib/tpm2_errata.h \
     lib/tpm2_header.h \
     lib/tpm2_nv_util.c \
     lib/tpm2_nv_util.h \

--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -1,0 +1,269 @@
+//**********************************************************************;
+// Copyright (c) 2017, Alibaba Group
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "log.h"
+#include "tpm2_errata.h"
+#include "tpm2_util.h"
+
+struct tpm2_errata_desc {
+    UINT32 spec_level;          /* spec level */
+    UINT32 spec_rev;            /* spec revision */
+    UINT32 errata_ver;          /* errata version */
+    void (*fixup)(va_list *ap); /* errata correction handler */
+    const char *name;           /* full section name in errata doc */
+};
+
+/*
+ * Published spec and errata information.
+ *
+ * Note that TPM_PT_YEAR and TPM_PT_DAY_OF_YEAR retrieved
+ * from capability query only have the values of the
+ * release date of the specification if the TPM does not
+ * implement an errata. So the spec info are also given.
+ */
+static struct tpm2_errata_info {
+    UINT32 spec_level;
+    UINT32 spec_rev;
+    UINT32 errata_ver;
+    UINT32 year;
+    UINT32 day_of_year;
+} known_errata_info[] = {
+    /* Specification Revision 1.16 October 30, 2014 */
+    { 00, 116, 000, 2014, 303 },
+    /* Errata Version 1.2 February 16, 2015 */
+    { 00, 116, 120, 2015,   4 },
+    /* Errata Version 1.3 June 16, 2015 */
+    { 00, 116, 130, 2015, 167 },
+    /* Errata Version 1.4 January 15, 2016 */
+    { 00, 116, 140, 2016,  15 },
+    /* Errata Version 1.5 September 21, 2016 */
+    { 00, 116, 150, 2016, 265 },
+    /* Specification Revision 1.38 September 29, 2016 */
+    { 00, 138, 000, 2016, 273 },
+    /* Errata Version 1.0 January 16, 2017 */
+    { 00, 138, 100, 2017,  16 },
+    /* Errata Version 1.1 March 2, 2017 */
+    { 00, 138, 110, 2017,  61 },
+};
+
+static struct tpm2_errata_info *this_errata_info;
+
+static void fixup_sign_decrypt_attribute_encoding(va_list *ap);
+
+/*
+ * Beware of that each record contains the first errata
+ * version with the corresponding correction. This rule
+ * allows errata_match() to function properly.
+ */
+static struct tpm2_errata_desc errata_desc_list[] = {
+    [SPEC_116_ERRATA_2_7] = {
+        .spec_level = 00,
+        .spec_rev = 116,
+        .errata_ver = 120,
+        .fixup = fixup_sign_decrypt_attribute_encoding,
+        .name = "Sign/decrypt attribute encoding",
+    },
+    /*
+     * Append the new errata descriptor here.
+     */
+};
+
+static bool errata_match(struct tpm2_errata_desc *errata);
+static struct tpm2_errata_desc *errata_query(tpm2_errata_index_t index);
+
+/*
+ * Request an errata correction.
+ * @index: the errata to be queried.
+ *
+ * This function requests an errata correction to work
+ * around a known issue well documented in errata doc.
+ * If the request is valid and known, the queried errata
+ * will be applied by the corresponding pre-defined errata
+ * correction handler. The fixup process is transparent to
+ * the callers so there is no return values. Any tools can
+ * call this function to apply an errata if necessary.
+ *
+ * Return value:
+ * N/A
+ */
+void tpm2_errata_fixup(tpm2_errata_index_t index, ...) {
+
+    struct tpm2_errata_desc *errata;
+
+    errata = errata_query(index);
+    if (!errata) {
+        return;
+    }
+
+    bool res = errata_match(errata);
+    if (res == false) {
+        return;
+    }
+
+    va_list ap;
+
+    va_start(ap, index);
+    errata->fixup(&ap);
+    va_end(ap);
+
+    LOG_INFO("Errata %s applied\n", errata->name);
+}
+
+/*
+ * Query the full name of an errata.
+ * @index: the errata to be queried.
+ *
+ * Return value:
+ * the full name of an errata, or NULL if the query fails.
+ */
+const char *tpm2_errata_name(tpm2_errata_index_t index) {
+
+    struct tpm2_errata_desc *errata;
+
+    errata = errata_query(index);
+    if (!errata) {
+        return NULL;
+    }
+
+    return errata->name;
+}
+
+/*
+ * Initialize errata subsystem.
+ * @sapi_ctx: SAPI context to be queried.
+ *
+ * Return value:
+ * return true if TPM_SPEC is known and valid, or false if opposite.
+ */
+bool tpm2_errata_init(TSS2_SYS_CONTEXT *sapi_ctx) {
+
+    TPMS_CAPABILITY_DATA capability_data;
+    TPMI_YES_NO more_data;
+    TSS2_RC rc;
+
+    rc = Tss2_Sys_GetCapability(sapi_ctx, NULL, TPM_CAP_TPM_PROPERTIES,
+                                PT_FIXED, MAX_TPM_PROPERTIES, &more_data,
+                                &capability_data, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, "
+                "TSS2_RC: 0x%x\n", TPM_CAP_TPM_PROPERTIES, PT_FIXED, rc);
+        return false;
+    } else if (more_data == YES) {
+        LOG_WARN("More data to be queried: capability: 0x%x, property: "
+                 "0x%x\n", TPM_CAP_TPM_PROPERTIES, PT_FIXED);
+    }
+
+    /* Distinguish current spec level 0 */
+    UINT32 spec_level = -1;
+    UINT32 spec_rev = 0;
+    UINT32 day_of_year = 0;
+    UINT32 year = 0;
+    TPML_TAGGED_TPM_PROPERTY *properties = &capability_data.data.tpmProperties;
+    size_t i;
+    for (i = 0; i < properties->count; ++i) {
+        TPMS_TAGGED_PROPERTY *property = properties->tpmProperty + i;
+
+        if (property->property == TPM_PT_LEVEL) {
+            spec_level = property->value;
+        } else if (property->property == TPM_PT_REVISION) {
+            spec_rev = property->value;
+        } else if (property->property == TPM_PT_DAY_OF_YEAR) {
+            day_of_year = property->value;
+        } else if (property->property == TPM_PT_YEAR) {
+            year = property->value;
+            /* Short circuit because this is the last item we need */
+            break;
+        } else if (property->property > TPM_PT_YEAR) {
+            break;
+        }
+    }
+
+    if (!spec_rev || !day_of_year || !year) {
+        LOG_ERR("Invalid TPM_SPEC parameter\n");
+        return false;
+    }
+
+    /* Determine the TPM spec and errata */
+    for (i = 0; i < ARRAY_LEN(known_errata_info); ++i) {
+         if (known_errata_info[i].day_of_year == day_of_year &&
+             known_errata_info[i].year == year &&
+             known_errata_info[i].spec_rev == spec_rev &&
+             known_errata_info[i].spec_level == spec_level) {
+             this_errata_info = known_errata_info + i;
+             break;
+         }
+    }
+
+    if (!this_errata_info) {
+        LOG_ERR("Unknow TPM_SPEC. spec_level: %d, spec_rev: 0x%x, "
+                "year: %d, day_of_year: %d\n", spec_level, spec_rev,
+                year, day_of_year);
+        return false;
+    }
+
+    LOG_INFO("TPM_SPEC: spec level %d, spec rev %f, errata ver %f\n",
+             this_errata_info->spec_level,
+             (float)this_errata_info->spec_rev / 100,
+             (float)this_errata_info->errata_ver / 100);
+
+    return true;
+}
+
+static void fixup_sign_decrypt_attribute_encoding(va_list *ap) {
+
+    TPMA_OBJECT *attrs = va_arg(*ap, TPMA_OBJECT *);
+
+    attrs->sign = 0;
+}
+
+static bool errata_match(struct tpm2_errata_desc *errata) {
+
+    if (!this_errata_info) {
+        LOG_ERR("Unrecognized TPM_SPEC for errata check\n");
+        return false;
+    }
+
+    return errata->errata_ver > this_errata_info->errata_ver &&
+           errata->spec_rev >= this_errata_info->spec_rev &&
+           errata->spec_level == this_errata_info->spec_level;
+}
+
+static struct tpm2_errata_desc *errata_query(tpm2_errata_index_t index) {
+
+    if ((size_t)index >= ARRAY_LEN(errata_desc_list)) {
+        LOG_ERR("Invalid errata index queried: %u\n", (unsigned int)index);
+        return NULL;
+    }
+
+    return &errata_desc_list[index];
+}

--- a/lib/tpm2_errata.h
+++ b/lib/tpm2_errata.h
@@ -1,0 +1,84 @@
+//**********************************************************************;
+// Copyright (c) 2017, Alibaba Group
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#ifndef TPM2_ERRATA_H
+#define TPM2_ERRATA_H
+
+#include <sapi/tpm20.h>
+#include <stdbool.h>
+
+/*
+ * Errata index pattern:
+ *   spec version + the section number in the errata doc
+ *
+ * Note that it is unnecessary to describe errata version
+ * because the section number should be kept consistent
+ * accoss all errata versions for a specific spec revision.
+ */
+typedef enum {
+    SPEC_116_ERRATA_2_7,
+} tpm2_errata_index_t;
+
+/*
+ * Initialize errata subsystem.
+ * @sapi_ctx: SAPI context to be queried.
+ *
+ * Return value:
+ * return true if TPM_SPEC is known and valid, or false if opposite.
+ */
+bool tpm2_errata_init(TSS2_SYS_CONTEXT *sapi_ctx);
+
+/*
+ * Request an errata correction.
+ * @index: the errata to be queried.
+ *
+ * This function requests an errata correction to work
+ * around a known issue well documented in errata doc.
+ * If the request is valid and known, the queried errata
+ * will be applied by the corresponding pre-defined errata
+ * correction handler. The fixup process is transparent to
+ * the callers so there is no return values. Any tools can
+ * call this function to apply an errata if necessary.
+ *
+ * Return value:
+ * N/A
+ */
+void tpm2_errata_fixup(tpm2_errata_index_t index, ...);
+
+/*
+ * Query the full name of an errata.
+ * @index: the errata to be queried.
+ *
+ * Return value:
+ * the full name of an errata, or NULL if the query fails.
+ */
+const char *tpm2_errata_name(tpm2_errata_index_t index);
+
+#endif /* TPM2_ERRATA_H */

--- a/test/system/test_helpers.sh
+++ b/test/system/test_helpers.sh
@@ -99,18 +99,3 @@ hash_alg_supported() {
         fi
     done
 }
-
-# Certain TPM 2.0 chip, e.g, Nationz Z32H320TC, and tpm2simulator referring
-# to TPM 2.0 spec rev 1.16 may have an errata, disallowing both decrypt and
-# sign set for a symcipher object, and in response to RC_ATTRIBUTES. In
-# order to work around it, we attempt to run tpm2_create again with sign bit
-# clear.
-create_object() {
-    local alg_create_obj=0x20072
-
-    if tpm2_create $@ 2>&1 | grep -q 'Create Object Failed ! ErrorCode: 0x2c2'; then
-        tpm2_create -Q -A $alg_create_obj $@
-    else
-        true
-    fi
-}

--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -57,7 +57,7 @@ tpm2_createprimary -Q -A o -g sha1 -G rsa -C context.out
 # values.
 for gAlg in `populate_hash_algs mixed`; do
     for GAlg in rsa 0x08 ecc 0x25; do
-        create_object -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
+        tpm2_create -Q -c context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
         cleanup keep_context
     done
 done
@@ -67,7 +67,7 @@ cleanup keep_context
 echo "f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988" \
 | xxd -r -p > policy.bin
 
-create_object -c context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv -E
+tpm2_create -Q -c context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv -E
 
 cmp -i 14:0 -n 32 key.pub policy.bin -s
 

--- a/test/system/test_tpm2_encryptdecrypt.sh
+++ b/test/system/test_tpm2_encryptdecrypt.sh
@@ -62,7 +62,7 @@ tpm2_takeownership -Q -c
 
 tpm2_createprimary -Q -A e -g sha1 -G rsa -C primary.ctx
 
-create_object -g sha256 -G symcipher -u key.pub -r key.priv -c primary.ctx
+tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -c primary.ctx
 
 tpm2_load -Q -c primary.ctx -u key.pub -r key.priv -n key.name -C decrypt.ctx
 

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -80,7 +80,7 @@ tpm2_takeownership -c
 
 tpm2_createprimary -Q -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 
-create_object -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -c $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -c $file_primary_key_ctx
 
 tpm2_load -Q -c $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -C $file_quote_key_ctx
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -46,6 +46,7 @@
 #include "files.h"
 #include "log.h"
 #include "tpm2_alg_util.h"
+#include "tpm2_errata.h"
 #include "tpm2_tool.h"
 
 typedef struct tpm_create_ctx tpm_create_ctx;
@@ -152,6 +153,9 @@ int setup_alg()
         break;
 
     case TPM_ALG_SYMCIPHER:
+        tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
+                          &ctx.in_public.t.publicArea.objectAttributes);
+
         ctx.in_public.t.publicArea.parameters.symDetail.sym.algorithm = TPM_ALG_AES;
         ctx.in_public.t.publicArea.parameters.symDetail.sym.keyBits.sym = 128;
         ctx.in_public.t.publicArea.parameters.symDetail.sym.mode.sym = TPM_ALG_CFB;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -49,6 +49,7 @@
 #include "log.h"
 #include "files.h"
 #include "tpm_kdfa.h"
+#include "tpm2_errata.h"
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
@@ -289,6 +290,9 @@ static bool calc_sensitive_unique_data(void) {
 static bool create_import_key_public_data_and_name(void) {
 
     IMPORT_KEY_SYM_PUBLIC_AREA(ctx.import_key_public)
+
+    tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
+                      &ctx.import_key_public.t.publicArea.objectAttributes);
 
     if (ctx.objectAttributes) {
         ctx.import_key_public.t.publicArea.objectAttributes.val = ctx.objectAttributes;

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -36,6 +36,7 @@
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
+#include "tpm2_errata.h"
 
 bool output_enabled = true;
 
@@ -133,6 +134,11 @@ int main(int argc, char *argv[], char *envp[]) {
 
     /* TODO SAPI INIT */
     TSS2_SYS_CONTEXT *sapi_context = sapi_ctx_init(tcti);
+
+    bool res = tpm2_errata_init(sapi_context);
+    if (res == false) {
+        LOG_WARN("TPM errata info is unavailable\n");
+    }
 
     /*
      * Call the specific tool, all tools implement this function instead of


### PR DESCRIPTION
The TPM errata should be addressed and handled transparently by design.

In order to handle an errata, the errata info should be recorded in
tpm2_errata.[ch], and the affected tools need to query the errata
handler with a pre-defined errata number and to-be-fixed contents.

During the initialization, the TPM spec and errata info will be
remembered and used to check the errata query issued by the tools.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>