### PR TITLE
tpm2_encryptdecrypt: Replace use of EncryptDecrypt with EncryptDecrypt2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ before_install:
     - pip install --user cpp-coveralls pyyaml
 
 install: 
-    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
-    - sha256sum ibmtpm532.tar | grep -q abc0b420257917ccb42a9750588565d5e84a2b4e99a6f9f46c3dad1f9912864f
-    - mkdir ibmtpm532 && pushd ibmtpm532 && tar xzf ../ibmtpm532.tar && pushd ./src && make
+    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz
+    - sha256sum ibmtpm974.tar.gz | grep -q 8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
+    - mkdir ibmtpm974 && pushd ibmtpm974 && tar axf ../ibmtpm974.tar.gz && pushd ./src && make
     - ./tpm_server &
     - popd && popd
     - git clone https://github.com/01org/TPM2.0-TSS.git

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -93,6 +93,19 @@
         .rspAuths = array, \
     }
 
+/*
+ * This macro is useful as a wrapper around SAPI functions to automatically
+ * retry function calls when the RC is TPM_RC_RETRY.
+ */
+#define TSS2_RETRY_EXP(expression)                         \
+    ({                                                     \
+        TSS2_RC __result = 0;                              \
+        do {                                               \
+            __result = (expression);                       \
+        } while ((__result & 0x0000ffff) == TPM_RC_RETRY); \
+        __result;                                          \
+    })
+
 int tpm2_util_hex_to_byte_structure(const char *inStr, UINT16 *byteLenth, BYTE *byteBuffer);
 
 /**

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -187,8 +187,8 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    rval = Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
-            session->sessionHandle, &cmd_auth_array_endorse, 0, 0, 0, 0, 0, 0, 0);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
+            session->sessionHandle, &cmd_auth_array_endorse, 0, 0, 0, 0, 0, 0, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:0x%x", rval);
         return false;
@@ -198,16 +198,16 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
     tmp_auth.sessionAttributes.continueSession = 1;
     tmp_auth.hmac.t.size = 0;
 
-    rval = Tss2_Sys_ActivateCredential(sapi_context, ctx.handle.activate,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_ActivateCredential(sapi_context, ctx.handle.activate,
             ctx.handle.key, &cmd_auth_array_password, &ctx.credentialBlob, &ctx.secret,
-            &certInfoData, 0);
+            &certInfoData, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("ActivateCredential failed. TPM Error:0x%x", rval);
         return false;
     }
 
     // Need to flush the session here.
-    rval = Tss2_Sys_FlushContext(sapi_context, session->sessionHandle);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, session->sessionHandle));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
         return false;

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -103,8 +103,8 @@ static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT object_h
 
     TPM2B_NAME qualified_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
 
-    TPM_RC rval = Tss2_Sys_ReadPublic(sapi_context, object_handle, 0,
-            &out_public, &name, &qualified_name, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, object_handle, 0,
+            &out_public, &name, &qualified_name, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_ReadPublic failed. Error Code: 0x%x", rval);
         return false;
@@ -191,9 +191,9 @@ static bool certify_and_save_data(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMT_SIGNATURE signature;
 
-    TPM_RC rval = Tss2_Sys_Certify(sapi_context, ctx.handle.obj,
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Certify(sapi_context, ctx.handle.obj,
             ctx.handle.key, &cmd_auth_array, &qualifying_data, &scheme,
-            &certify_info, &signature, &sessions_data_out);
+            &certify_info, &signature, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_Certify failed. Error Code: 0x%x", rval);
         return false;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -209,9 +209,9 @@ int create(TSS2_SYS_CONTEXT *sapi_context)
 
     creationPCR.count = 0;
 
-    rval = Tss2_Sys_Create(sapi_context, ctx.parent_handle, &sessionsData, &ctx.in_sensitive,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_Create(sapi_context, ctx.parent_handle, &sessionsData, &ctx.in_sensitive,
                            &ctx.in_public, &outsideInfo, &creationPCR, &outPrivate,&outPublic,
-                           &creationData, &creationHash, &creationTicket, &sessionsDataOut);
+                           &creationData, &creationHash, &creationTicket, &sessionsDataOut));
     if(rval != TPM_RC_SUCCESS) {
         LOG_ERR("\nCreate Object Failed ! ErrorCode: 0x%0x\n",rval);
         return -2;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -188,10 +188,10 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
 
     creationPCR.count = 0;
 
-    rval = Tss2_Sys_CreatePrimary(sapi_context, ctx.hierarchy, &sessionsData,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_CreatePrimary(sapi_context, ctx.hierarchy, &sessionsData,
                                   &ctx.inSensitive, &ctx.in_public, &outsideInfo, &creationPCR,
                                   &handle2048rsa, &outPublic, &creationData, &creationHash,
-                                  &creationTicket, &name, &sessionsDataOut);
+                                  &creationTicket, &name, &sessionsDataOut));
     if(rval != TPM_RC_SUCCESS) {
         LOG_ERR("\nCreatePrimary Failed ! ErrorCode: 0x%0x\n", rval);
         return -2;

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -80,8 +80,8 @@ bool dictionary_lockout_reset_and_parameter_setup(TSS2_SYS_CONTEXT *sapi_context
     if (ctx.clear_lockout) {
 
         LOG_INFO("Resetting dictionary lockout state.");
-        UINT32 rval = Tss2_Sys_DictionaryAttackLockReset(sapi_context,
-                TPM_RH_LOCKOUT, &sessionsData, &sessionsDataOut);
+        UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_DictionaryAttackLockReset(sapi_context,
+                TPM_RH_LOCKOUT, &sessionsData, &sessionsDataOut));
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("0x%X Error clearing dictionary lockout.", rval);
             return false;
@@ -90,10 +90,10 @@ bool dictionary_lockout_reset_and_parameter_setup(TSS2_SYS_CONTEXT *sapi_context
 
     if (ctx.setup_parameters) {
         LOG_INFO("Setting up Dictionary Lockout parameters.");
-        UINT32 rval = Tss2_Sys_DictionaryAttackParameters(sapi_context,
+        UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_DictionaryAttackParameters(sapi_context,
                 TPM_RH_LOCKOUT, &sessionsData, ctx.max_tries,
                 ctx.recovery_time, ctx.lockout_recovery_time,
-                &sessionsDataOut);
+                &sessionsDataOut));
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR(
                     "0x%X Failed setting up dictionary_attack_lockout_reset params",

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -43,6 +43,7 @@
 #include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
+#include "rc-decode.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -99,9 +100,15 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
         },
     };
 
-    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
+    /* try EncryptDecrypt2 first, fallback to EncryptDecrypt if not supported */
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt2(sapi_context, ctx.key_handle,
             &sessions_data, &ctx.data, ctx.is_decrypt, TPM_ALG_NULL, &iv_in, &out_data,
             &iv_out, &sessions_data_out));
+    if (rval == TPM_RC_COMMAND_CODE) {
+        rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
+                &sessions_data, ctx.is_decrypt, TPM_ALG_NULL, &iv_in, &ctx.data,
+                &out_data, &iv_out, &sessions_data_out));
+    }
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("EncryptDecrypt failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -99,9 +99,9 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
         },
     };
 
-    TPM_RC rval = Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
-            &sessions_data, ctx.is_decrypt, TPM_ALG_NULL, &iv_in, &ctx.data, &out_data,
-            &iv_out, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
+            &sessions_data, &ctx.data, ctx.is_decrypt, TPM_ALG_NULL, &iv_in, &out_data,
+            &iv_out, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("EncryptDecrypt failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -86,8 +86,8 @@ static int evict_control(TSS2_SYS_CONTEXT *sapi_context) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_EvictControl(sapi_context, ctx.auth, ctx.handle.object,
-                                        &sessions_data, ctx.handle.persist,&sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, ctx.auth, ctx.handle.object,
+                                        &sessions_data, ctx.handle.persist,&sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("EvictControl failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -749,14 +749,14 @@ get_tpm_capability_all (TSS2_SYS_CONTEXT *sapi_ctx,
     TSS2_RC                rc;
     TPMI_YES_NO            more_data;
 
-    rc = Tss2_Sys_GetCapability (sapi_ctx,
+    rc = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_ctx,
                                  NULL,
                                  options.capability,
                                  options.property,
                                  options.count,
                                  &more_data,
                                  capability_data,
-                                 NULL);
+                                 NULL));
     if (rc != TSS2_RC_SUCCESS) {
         LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, "
                  "TSS2_RC: 0x%x\n", options.capability, options.property, rc);

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -184,11 +184,11 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
 
     creationPCR.count = 0;
 
-    rval = Tss2_Sys_CreatePrimary(sapi_context, TPM_RH_ENDORSEMENT, &sessionsData,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_CreatePrimary(sapi_context, TPM_RH_ENDORSEMENT, &sessionsData,
                                   &inSensitive, &inPublic, &outsideInfo,
                                   &creationPCR, &handle2048ek, &outPublic,
                                   &creationData, &creationHash, &creationTicket,
-                                  &name, &sessionsDataOut);
+                                  &name, &sessionsDataOut));
     if (rval != TPM_RC_SUCCESS ) {
           LOG_ERR("TPM2_CreatePrimary Error. TPM Error:0x%x", rval);
           return 1;
@@ -204,8 +204,8 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
 
         sessionDataArray[0] = &ctx.owner_session_data;
 
-        rval = Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, handle2048ek,
-                                     &sessionsData, ctx.persistent_handle, &sessionsDataOut);
+        rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, handle2048ek,
+                                     &sessionsData, ctx.persistent_handle, &sessionsDataOut));
         if (rval != TPM_RC_SUCCESS ) {
             LOG_ERR("EvictControl:Make EK persistent Error. TPM Error:0x%x", rval);
             return 1;
@@ -213,8 +213,8 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
         LOG_INFO("EvictControl EK persistent succ.");
     }
 
-    rval = Tss2_Sys_FlushContext(sapi_context,
-                                 handle2048ek);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
+                                 handle2048ek));
     if (rval != TPM_RC_SUCCESS ) {
         LOG_ERR("Flush transient EK failed. TPM Error:0x%x", rval);
         return 1;

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -266,8 +266,8 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
 
     LOG_INFO("tpm_session_start_auth_with_params succ");
 
-    rval = Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
-            session->sessionHandle, &sessions_data, 0, 0, 0, 0, 0, 0, 0);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
+            session->sessionHandle, &sessions_data, 0, 0, 0, 0, 0, 0, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:0x%x", rval);
         return false;
@@ -279,10 +279,10 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     session_data.sessionAttributes.continueSession = 1;
     session_data.hmac.t.size = 0;
 
-    rval = Tss2_Sys_Create(sapi_context, handle_2048_rsa, &sessions_data,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_Create(sapi_context, handle_2048_rsa, &sessions_data,
             &inSensitive, &inPublic, &outsideInfo, &creation_pcr, &out_private,
             &out_public, &creation_data, &creation_hash, &creation_ticket,
-            &sessions_data_out);
+            &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_Create Error. TPM Error:0x%x", rval);
         return false;
@@ -290,7 +290,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     LOG_INFO("TPM2_Create succ");
 
     // Need to flush the session here.
-    rval = Tss2_Sys_FlushContext(sapi_context, session->sessionHandle);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, session->sessionHandle));
     if (rval != TPM_RC_SUCCESS) {
         LOG_INFO("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
         return false;
@@ -313,8 +313,8 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     }
     LOG_INFO("tpm_session_start_auth_with_params succ");
 
-    rval = Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
-            session->sessionHandle, &sessions_data, 0, 0, 0, 0, 0, 0, 0);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM_RH_ENDORSEMENT,
+            session->sessionHandle, &sessions_data, 0, 0, 0, 0, 0, 0, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:0x%x", rval);
         return false;
@@ -326,8 +326,8 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     session_data.hmac.t.size = 0;
 
     TPM_HANDLE loaded_sha1_key_handle;
-    rval = Tss2_Sys_Load(sapi_context, handle_2048_rsa, &sessions_data, &out_private,
-            &out_public, &loaded_sha1_key_handle, &name, &sessions_data_out);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_Load(sapi_context, handle_2048_rsa, &sessions_data, &out_private,
+            &out_public, &loaded_sha1_key_handle, &name, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_Load Error. TPM Error:0x%x", rval);
         return false;
@@ -347,7 +347,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     // Need to flush the session here.
-    rval = Tss2_Sys_FlushContext(sapi_context, session->sessionHandle);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, session->sessionHandle));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
         return false;
@@ -363,8 +363,8 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     // use the owner auth here.
     memcpy(&session_data.hmac, &ctx.passwords.owner, sizeof(ctx.passwords.owner));
 
-    rval = Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, loaded_sha1_key_handle,
-            &sessions_data, ctx.persistent_handle.ak, &sessions_data_out);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, loaded_sha1_key_handle,
+            &sessions_data, ctx.persistent_handle.ak, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("\n......TPM2_EvictControl Error. TPM Error:0x%x......",
                 rval);
@@ -372,7 +372,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     }
     LOG_INFO("EvictControl: Make AK persistent succ.");
 
-    rval = Tss2_Sys_FlushContext(sapi_context, loaded_sha1_key_handle);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, loaded_sha1_key_handle));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Flush transient AK error. TPM Error:0x%x", rval);
         return false;

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -204,10 +204,10 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
 
     /* Create EK and get a handle to the key */
     TPM_HANDLE handle2048ek;
-    UINT32 rval = Tss2_Sys_CreatePrimary(sapi_context, TPM_RH_ENDORSEMENT,
+    UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_CreatePrimary(sapi_context, TPM_RH_ENDORSEMENT,
             &sessionsData, &inSensitive, &inPublic, &outsideInfo, &creationPCR,
             &handle2048ek, &outPublic, &creationData, &creationHash,
-            &creationTicket, &name, &sessionsDataOut);
+            &creationTicket, &name, &sessionsDataOut));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_CreatePrimary Error. TPM Error:0x%x", rval);
         return false;
@@ -217,8 +217,8 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
 
     memcpy(&sessionData.hmac, &ctx.passwords.owner, sizeof(ctx.passwords.owner));
 
-    rval = Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, handle2048ek,
-            &sessionsData, ctx.persistent_handle, &sessionsDataOut);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM_RH_OWNER, handle2048ek,
+            &sessionsData, ctx.persistent_handle, &sessionsDataOut));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("EvictControl failed. Could not make EK persistent."
                 "TPM Error:0x%x", rval);
@@ -227,7 +227,7 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
 
     LOG_INFO("EvictControl EK persistent success.");
 
-    rval = Tss2_Sys_FlushContext(sapi_context, handle2048ek);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handle2048ek));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Flush transient EK failed. TPM Error:0x%x",
                 rval);

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -56,8 +56,8 @@ static bool get_random_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPM2B_DIGEST random_bytes = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
 
-    TPM_RC rval = Tss2_Sys_GetRandom(sapi_context, NULL, ctx.num_of_bytes,
-            &random_bytes, NULL);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetRandom(sapi_context, NULL, ctx.num_of_bytes,
+            &random_bytes, NULL));
     if (rval != TSS2_RC_SUCCESS) {
         LOG_ERR("TPM2_GetRandom Error. TPM Error:0x%x", rval);
         return false;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -103,9 +103,9 @@ TPM_RC tpm_hmac_file(TSS2_SYS_CONTEXT *sapi_context, TPM2B_DIGEST *result) {
             return TSS2_APP_HMAC_RC_FAILED;
         }
 
-        return Tss2_Sys_HMAC(sapi_context, ctx.key_handle,
+        return TSS2_RETRY_EXP(Tss2_Sys_HMAC(sapi_context, ctx.key_handle,
                 &sessions_data, &buffer, ctx.algorithm, result,
-                &sessions_data_out);
+                &sessions_data_out));
     }
 
     TPM2B_AUTH null_auth = { .t.size = 0 };
@@ -116,8 +116,8 @@ TPM_RC tpm_hmac_file(TSS2_SYS_CONTEXT *sapi_context, TPM2B_DIGEST *result) {
      * to do in a single hash call. Based on the size figure out the chunks
      * to loop over, if possible. This way we can call Complete with data.
      */
-    TPM_RC rval = Tss2_Sys_HMAC_Start(sapi_context, ctx.key_handle, &sessions_data,
-            &null_auth, ctx.algorithm, &sequence_handle, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_HMAC_Start(sapi_context, ctx.key_handle, &sessions_data,
+            &null_auth, ctx.algorithm, &sequence_handle, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_HMAC_Start failed: 0x%X", rval);
         return rval;
@@ -144,8 +144,8 @@ TPM_RC tpm_hmac_file(TSS2_SYS_CONTEXT *sapi_context, TPM2B_DIGEST *result) {
         data.t.size = bytes_read;
 
         /* if data was read, update the sequence */
-        rval = Tss2_Sys_SequenceUpdate(sapi_context, sequence_handle,
-                &sessions_data, &data, &sessions_data_out);
+        rval = TSS2_RETRY_EXP(Tss2_Sys_SequenceUpdate(sapi_context, sequence_handle,
+                &sessions_data, &data, &sessions_data_out));
         if (rval != TPM_RC_SUCCESS) {
             return rval;
         }
@@ -172,9 +172,9 @@ TPM_RC tpm_hmac_file(TSS2_SYS_CONTEXT *sapi_context, TPM2B_DIGEST *result) {
         data.t.size = 0;
     }
 
-    return Tss2_Sys_SequenceComplete(sapi_context, sequence_handle,
+    return TSS2_RETRY_EXP(Tss2_Sys_SequenceComplete(sapi_context, sequence_handle,
             &sessions_data, &data, TPM_RH_NULL, result, NULL,
-            &sessions_data_out);
+            &sessions_data_out));
 }
 
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -479,10 +479,10 @@ static bool import_external_key_and_save_public_private_data(TSS2_SYS_CONTEXT *s
     memcpy(enc_inp_seed.t.secret, ctx.encrypted_protection_seed_data,
             MAX_RSA_KEY_BYTES);
 
-    TPM_RC rval = Tss2_Sys_Import(sapi_context, ctx.parent_key_handle,
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Import(sapi_context, ctx.parent_key_handle,
             &npsessionsData, &ctx.enc_sensitive_key, &ctx.import_key_public,
             &ctx.import_key_private, &enc_inp_seed, &symmetricAlg,
-            &importPrivate, &npsessionsDataOut);
+            &importPrivate, &npsessionsDataOut));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed Key Import %08X", rval);
         return false;

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -94,7 +94,7 @@ int readPublic(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT objectHandle) {
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
     sessionsDataOut.rspAuthsCount = 1;
 
-    rval = Tss2_Sys_ReadPublic(sapi_context, objectHandle, 0, &outPublic, &name, &qualifiedName, &sessionsDataOut);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, objectHandle, 0, &outPublic, &name, &qualifiedName, &sessionsDataOut));
     if(rval != TPM_RC_SUCCESS)
     {
         LOG_ERR("\nTPM2_ReadPublic error: rval = 0x%0x\n",rval);
@@ -137,9 +137,9 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     UINT32 rval;
 
     UINT32 property = tpm2_util_endian_swap_32(TPM_HT_PERSISTENT);
-    rval = Tss2_Sys_GetCapability( sapi_context, 0, TPM_CAP_HANDLES,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability(sapi_context, 0, TPM_CAP_HANDLES,
                                    property, TPM_PT_HR_PERSISTENT, &moreData,
-                                   &capabilityData, 0 );
+                                   &capabilityData, 0));
     if(rval != TPM_RC_SUCCESS)
     {
         LOG_ERR("\n......GetCapability: Get persistent object list Error."

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -95,14 +95,14 @@ int load (TSS2_SYS_CONTEXT *sapi_context) {
     sessionsDataOut.rspAuthsCount = 1;
     sessionsData.cmdAuthsCount = 1;
 
-    rval = Tss2_Sys_Load(sapi_context,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_Load(sapi_context,
                          ctx.parent_handle,
                          &sessionsData,
                          &ctx.in_private,
                          &ctx.in_public,
                          &handle2048rsa,
                          &nameExt,
-                         &sessionsDataOut);
+                         &sessionsDataOut));
     if(rval != TPM_RC_SUCCESS)
     {
         LOG_ERR("\nLoad Object Failed ! ErrorCode: 0x%0x\n",rval);

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -101,10 +101,10 @@ static bool load_external(TSS2_SYS_CONTEXT *sapi_context) {
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
     sessionsDataOut.rspAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_LoadExternal(sapi_context, 0,
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_LoadExternal(sapi_context, 0,
             ctx.has_private_key ? &ctx.private_key : NULL, &ctx.public_key,
             ctx.hierarchy_value, &ctx.rsa2048_handle, &nameExt,
-            &sessionsDataOut);
+            &sessionsDataOut));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("LoadExternal Failed ! ErrorCode: 0x%0x", rval);
         return false;

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -114,22 +114,22 @@ static bool make_credential_and_save(TSS2_SYS_CONTEXT *sapi_context)
     sessions_data_out.rspAuths = &session_data_out_array[0];
     sessions_data_out.rspAuthsCount = 1;
 
-    UINT32 rval = Tss2_Sys_LoadExternal(sapi_context, 0, NULL, &ctx.public,
-            TPM_RH_NULL, &ctx.rsa2048_handle, &name_ext, &sessions_data_out);
+    UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_LoadExternal(sapi_context, 0, NULL, &ctx.public,
+            TPM_RH_NULL, &ctx.rsa2048_handle, &name_ext, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("LoadExternal failed. TPM Error:0x%x", rval);
         return false;
     }
 
-    rval = Tss2_Sys_MakeCredential(sapi_context, ctx.rsa2048_handle, 0,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_MakeCredential(sapi_context, ctx.rsa2048_handle, 0,
             &ctx.credential, &ctx.object_name, &cred_blob, &secret,
-            &sessions_data_out);
+            &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("MakeCredential failed. TPM Error:0x%x", rval);
         return false;
     }
 
-    rval = Tss2_Sys_FlushContext(sapi_context, ctx.rsa2048_handle);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, ctx.rsa2048_handle));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Flush loaded key failed. TPM Error:0x%x", rval);
         return false;

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -102,8 +102,8 @@ static int nv_space_define(TSS2_SYS_CONTEXT *sapi_context) {
 
     public_info.t.nvPublic.dataSize = ctx.size;
 
-    TPM_RC rval = Tss2_Sys_NV_DefineSpace(sapi_context, ctx.authHandle,
-            &sessions_data, &ctx.nvAuth, &public_info, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_DefineSpace(sapi_context, ctx.authHandle,
+            &sessions_data, &ctx.nvAuth, &public_info, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to define NV area at index 0x%x (%d).Error:0x%x",
                 ctx.nvIndex, ctx.nvIndex, rval);

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -69,8 +69,8 @@ static bool nv_list(TSS2_SYS_CONTEXT *sapi_context) {
     TPMI_YES_NO moreData;
     TPMS_CAPABILITY_DATA capabilityData;
     UINT32 property = tpm2_util_endian_swap_32(TPM_HT_NV_INDEX);
-    TPM_RC rval = Tss2_Sys_GetCapability(sapi_context, 0, TPM_CAP_HANDLES,
-            property, TPM_PT_NV_INDEX_MAX, &moreData, &capabilityData, 0);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability(sapi_context, 0, TPM_CAP_HANDLES,
+            property, TPM_PT_NV_INDEX_MAX, &moreData, &capabilityData, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("GetCapability:Get NV Index list Error. TPM Error:0x%x", rval);
         return false;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -148,8 +148,8 @@ static bool nv_read(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         UINT16 bytes_to_read = ctx.size_to_read > MAX_NV_BUFFER_SIZE ?
                         MAX_NV_BUFFER_SIZE : ctx.size_to_read;
 
-        rval = Tss2_Sys_NV_Read(sapi_context, ctx.auth_handle, ctx.nv_index,
-                &sessions_data, bytes_to_read, ctx.offset, &nv_data, &sessions_data_out);
+        rval = TSS2_RETRY_EXP(Tss2_Sys_NV_Read(sapi_context, ctx.auth_handle, ctx.nv_index,
+                &sessions_data, bytes_to_read, ctx.offset, &nv_data, &sessions_data_out));
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("Failed to read NVRAM area at index 0x%x (%d). Error:0x%x",
                     ctx.nv_index, ctx.nv_index, rval);

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -77,8 +77,8 @@ static bool nv_readlock(TSS2_SYS_CONTEXT *sapi_context) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_NV_ReadLock(sapi_context, ctx.auth_handle, ctx.nv_index,
-            &sessions_data, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_ReadLock(sapi_context, ctx.auth_handle, ctx.nv_index,
+            &sessions_data, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to lock NVRAM area at index 0x%x (%d).Error:0x%x",
                 ctx.nv_index, ctx.nv_index, rval);

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -62,8 +62,8 @@ static bool nv_space_release(TSS2_SYS_CONTEXT *sapi_context) {
     sessions_data.cmdAuths = &session_data_array[0];
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_NV_UndefineSpace(sapi_context, ctx.auth_handle,
-                                            ctx.nv_index, &sessions_data, 0);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_UndefineSpace(sapi_context, ctx.auth_handle,
+                                            ctx.nv_index, &sessions_data, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed to release NV area at index 0x%x (%d).Error:0x%x",
                 ctx.nv_index, ctx.nv_index, rval);

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -92,9 +92,9 @@ static int nv_write(TSS2_SYS_CONTEXT *sapi_context) {
         }
         tpm2_tool_output("\n\n");
 
-        TPM_RC rval = Tss2_Sys_NV_Write(sapi_context, ctx.auth_handle,
+        TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_Write(sapi_context, ctx.auth_handle,
                 ctx.nv_index, &sessions_data, &nv_write_data, offset,
-                &sessions_data_out);
+                &sessions_data_out));
         if (rval != TSS2_RC_SUCCESS) {
             LOG_ERR(
                     "Failed to write NV area at index 0x%x (%d) offset 0x%x. Error:0x%x",

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -108,9 +108,9 @@ static TPM_RC tpm_pcrevent_file(TSS2_SYS_CONTEXT *sapi_context,
             return TSS2_APP_PCREVENT_RC_FAILED;
         }
 
-        return Tss2_Sys_PCR_Event(sapi_context, ctx.pcr, &cmd_auth_array,
+        return TSS2_RETRY_EXP(Tss2_Sys_PCR_Event(sapi_context, ctx.pcr, &cmd_auth_array,
                 &buffer, result,
-                NULL);
+                NULL));
     }
 
     TPMI_DH_OBJECT sequence_handle;
@@ -121,8 +121,8 @@ static TPM_RC tpm_pcrevent_file(TSS2_SYS_CONTEXT *sapi_context,
      * to do in a single hash call. Based on the size figure out the chunks
      * to loop over, if possible. This way we can call Complete with data.
      */
-    TPM_RC rval = Tss2_Sys_HashSequenceStart(sapi_context, NULL, &nullAuth,
-    TPM_ALG_NULL, &sequence_handle, NULL);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_HashSequenceStart(sapi_context, NULL, &nullAuth,
+    TPM_ALG_NULL, &sequence_handle, NULL));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_HashSequenceStart failed: 0x%X", rval);
         return rval;
@@ -156,8 +156,8 @@ static TPM_RC tpm_pcrevent_file(TSS2_SYS_CONTEXT *sapi_context,
         data.t.size = bytes_read;
 
         /* if data was read, update the sequence */
-        rval = Tss2_Sys_SequenceUpdate(sapi_context, sequence_handle,
-                &cmd_auth_array, &data, NULL);
+        rval = TSS2_RETRY_EXP(Tss2_Sys_SequenceUpdate(sapi_context, sequence_handle,
+                &cmd_auth_array, &data, NULL));
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("Tss2_Sys_SequenceUpdate failed: 0x%X", rval);
             return rval;
@@ -193,8 +193,8 @@ static TPM_RC tpm_pcrevent_file(TSS2_SYS_CONTEXT *sapi_context,
     swap_auths(all_auths);
     cmd_auth_array.cmdAuthsCount = 2;
 
-    return Tss2_Sys_EventSequenceComplete(sapi_context, ctx.pcr,
-            sequence_handle, &cmd_auth_array, &data, result, NULL);
+    return TSS2_RETRY_EXP(Tss2_Sys_EventSequenceComplete(sapi_context, ctx.pcr,
+            sequence_handle, &cmd_auth_array, &data, result, NULL));
 }
 
 static bool do_hmac_and_output(TSS2_SYS_CONTEXT *sapi_context) {

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -72,8 +72,8 @@ static bool pcr_extend_one(TSS2_SYS_CONTEXT *sapi_context,
     sessions_data.cmdAuthsCount = 1;
     sessions_data_out.rspAuthsCount = 1;
 
-    TPM_RC rc = Tss2_Sys_PCR_Extend(sapi_context, pcr_index, &sessions_data,
-            digests, &sessions_data_out);
+    TPM_RC rc = TSS2_RETRY_EXP(Tss2_Sys_PCR_Extend(sapi_context, pcr_index, &sessions_data,
+            digests, &sessions_data_out));
     if (rc != TPM_RC_SUCCESS) {
         LOG_ERR("Could not extend pcr index: 0x%X, due to error: 0x%X",
                 pcr_index, rc);

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -148,9 +148,9 @@ static bool read_pcr_values(TSS2_SYS_CONTEXT *sapi_context) {
     //2. call pcr_read
     ctx.pcrs.count = 0;
     do {
-        UINT32 rval = Tss2_Sys_PCR_Read(sapi_context, no_argument, &pcr_selection_tmp,
+        UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_PCR_Read(sapi_context, no_argument, &pcr_selection_tmp,
                 &pcr_update_counter, &pcr_selection_out,
-                &ctx.pcrs.pcr_values[ctx.pcrs.count], 0);
+                &ctx.pcrs.pcr_values[ctx.pcrs.count], 0));
 
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("read pcr failed. tpm error 0x%0x", rval);
@@ -350,8 +350,8 @@ static bool get_banks(TSS2_SYS_CONTEXT *sapi_context) {
     TPMS_CAPABILITY_DATA *capability_data = &ctx.cap_data;
     UINT32 rval;
 
-    rval = Tss2_Sys_GetCapability(sapi_context, no_argument, TPM_CAP_PCRS, no_argument, required_argument,
-            &more_data, capability_data, 0);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability(sapi_context, no_argument, TPM_CAP_PCRS, no_argument, required_argument,
+            &more_data, capability_data, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR(
                 "GetCapability: Get PCR allocation status Error. TPM Error:0x%x......",

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -299,9 +299,9 @@ static int quote(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE akHandle, TPML_PCR_S
 
     memset( (void *)&signature, 0, sizeof(signature) );
 
-    rval = Tss2_Sys_Quote(sapi_context, akHandle, &sessionsData,
+    rval = TSS2_RETRY_EXP(Tss2_Sys_Quote(sapi_context, akHandle, &sessionsData,
             &qualifyingData, &inScheme, pcrSelection, &quoted,
-            &signature, &sessionsDataOut );
+            &signature, &sessionsDataOut));
     if(rval != TPM_RC_SUCCESS)
     {
         printf("\nQuote Failed ! ErrorCode: 0x%0x\n\n", rval);

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -77,8 +77,8 @@ static int read_public_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     sessions_out_data.rspAuths = &session_out_data_array[0];
     sessions_out_data.rspAuthsCount = ARRAY_LEN(session_out_data_array);
 
-    TPM_RC rval = Tss2_Sys_ReadPublic(sapi_context, ctx.objectHandle, 0,
-            &public, &name, &qualified_name, &sessions_out_data);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, ctx.objectHandle, 0,
+            &public, &name, &qualified_name, &sessions_out_data));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("TPM2_ReadPublic error: rval = 0x%0x", rval);
         return false;

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -85,9 +85,9 @@ static bool rsa_decrypt_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     inScheme.scheme = TPM_ALG_RSAES;
     label.t.size = 0;
 
-    TPM_RC rval = Tss2_Sys_RSA_Decrypt(sapi_context, ctx.key_handle,
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_RSA_Decrypt(sapi_context, ctx.key_handle,
             &sessions_data, &ctx.cipher_text, &inScheme, &label, &message,
-            &sessions_data_out);
+            &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("rsaDecrypt failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -77,8 +77,8 @@ static bool rsa_encrypt_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     scheme.scheme = TPM_ALG_RSAES;
     label.t.size = 0;
 
-    TPM_RC rval = Tss2_Sys_RSA_Encrypt(sapi_context, ctx.key_handle, NULL,
-            &ctx.message, &scheme, &label, &out_data, &out_sessions_data);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_RSA_Encrypt(sapi_context, ctx.key_handle, NULL,
+            &ctx.message, &scheme, &label, &out_data, &out_sessions_data));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("RSA_Encrypt failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -110,9 +110,9 @@ static bool sign_and_save(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    TPM_RC rval = Tss2_Sys_Sign(sapi_context, ctx.keyHandle,
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Sign(sapi_context, ctx.keyHandle,
             &sessions_data, &digest, &in_scheme, &ctx.validation, &signature,
-            &sessions_data_out);
+            &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Sys_Sign failed, error code: 0x%x", rval);
         return false;

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -85,7 +85,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     LOG_INFO ("Sending TPM_Startup command with type: %s",
             ctx.clear ? "TPM_SU_CLEAR" : "TPM_SU_STATE");
 
-    TPM_RC rc = Tss2_Sys_Startup (sapi_context, startup_type);
+    TPM_RC rc = TSS2_RETRY_EXP(Tss2_Sys_Startup (sapi_context, startup_type));
     if (rc != TSS2_RC_SUCCESS && rc != TPM_RC_INITIALIZE) {
         LOG_ERR ("Tss2_Sys_Startup failed: 0x%x",
                  rc);

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -80,7 +80,7 @@ static bool clear_hierarchy_auth(TSS2_SYS_CONTEXT *sapi_context) {
 
     memcpy(&sessionData.hmac, &ctx.passwords.lockout.old, sizeof(ctx.passwords.lockout.old));
 
-    TPM_RC rval = Tss2_Sys_Clear(sapi_context, TPM_RH_LOCKOUT, &sessionsData, 0);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Clear(sapi_context, TPM_RH_LOCKOUT, &sessionsData, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Clearing Failed! TPM error code: 0x%0x", rval);
         return false;
@@ -110,8 +110,8 @@ static bool change_auth(TSS2_SYS_CONTEXT *sapi_context,
     memcpy(&newAuth, &pwd->new, sizeof(pwd->new));
     memcpy(&sessionData.hmac, &pwd->old, sizeof(pwd->old));
 
-    UINT32 rval = Tss2_Sys_HierarchyChangeAuth(sapi_context,
-            auth_handle, &sessionsData, &newAuth, 0);
+    UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_HierarchyChangeAuth(sapi_context,
+            auth_handle, &sessionsData, &newAuth, 0));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Could not change hierarchy for %s. TPM Error:0x%x",
                 desc, rval);

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -87,8 +87,8 @@ bool unseal_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     sessions_data_out.rspAuthsCount = 1;
     sessions_data.cmdAuthsCount = 1;
 
-    TPM_RC rval = Tss2_Sys_Unseal(sapi_context, ctx.itemHandle,
-            &sessions_data, &outData, &sessions_data_out);
+    TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Unseal(sapi_context, ctx.itemHandle,
+            &sessions_data, &outData, &sessions_data_out));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Sys_Unseal failed. Error Code: 0x%x", rval);
         return false;
@@ -226,8 +226,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     if (ctx.policy_session) {
-        TPM_RC rval = Tss2_Sys_FlushContext(sapi_context,
-                                            ctx.policy_session->sessionHandle);
+        TPM_RC rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
+                                            ctx.policy_session->sessionHandle));
         if (rval != TPM_RC_SUCCESS) {
             LOG_ERR("Failed Flush Context: 0x%x", rval);
             return 1;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -93,8 +93,8 @@ static bool verify_signature(TSS2_SYS_CONTEXT *sapi_context) {
     }
     tpm2_tool_output("\n");
 
-    rval = Tss2_Sys_VerifySignature(sapi_context, ctx.keyHandle, NULL,
-            &ctx.msgHash, &ctx.signature, &validation, &sessionsDataOut);
+    rval = TSS2_RETRY_EXP(Tss2_Sys_VerifySignature(sapi_context, ctx.keyHandle, NULL,
+            &ctx.msgHash, &ctx.signature, &validation, &sessionsDataOut));
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Tss2_Sys_VerifySignature failed, error code: 0x%x", rval);
         return false;


### PR DESCRIPTION
The EncryptDecrypt command has been deprecated. The specification
identifies the EncryptDecrypt2 command as preferred.

Signed-off-by: Philip Tricca <flihp@twobit.us>