### PR TITLE
[V0] tpm2_getcap: correct option names

### DIFF
--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -52,11 +52,11 @@ command.
     * handles-nv-index:
       Display handles about NV Indices.
 
-    * handles-hmac-session:
-      Display handles about HMAC sessions.
+    * handles-loaded-session:
+      Display handles about both loaded HMAC and policy sessions.
 
-    * handles-policy-session:
-      Display handles about policy sessions.
+    * handles-saved-session:
+      Display handles about saved sessions.
 
 [common options](common/options.md)
 

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -116,15 +116,15 @@ capability_map_entry_t capability_map[] = {
         .count             = MAX_CAP_HANDLES,
     },
     {
-        .capability_string = "handles-hmac-session",
+        .capability_string = "handles-loaded-session",
         .capability        = TPM_CAP_HANDLES,
-        .property          = HMAC_SESSION_FIRST,
+        .property          = LOADED_SESSION_FIRST,
         .count             = MAX_CAP_HANDLES,
     },
     {
-        .capability_string = "handles-policy-session",
+        .capability_string = "handles-saved-session",
         .capability        = TPM_CAP_HANDLES,
-        .property          = POLICY_SESSION_FIRST,
+        .property          = ACTIVE_SESSION_FIRST,
         .count             = MAX_CAP_HANDLES,
     },
 };
@@ -812,8 +812,8 @@ static int dump_tpm_capability (TPMU_CAPABILITIES *capabilities) {
         case HR_PERMANENT:
         case HR_PCR:
         case HR_NV_INDEX:
-        case HR_HMAC_SESSION:
-        case HR_POLICY_SESSION:
+        case TPM_HT_LOADED_SESSION << HR_SHIFT:
+        case TPM_HT_SAVED_SESSION << HR_SHIFT:
             dump_handles (capabilities->handles.handle,
                           capabilities->handles.count);
             break;


### PR DESCRIPTION
handles-hmac-session and handles-policy-session should be replaced by
handles-loaded-session and handles-saved-session. According to the
spec, TPM_HT_LOADED_SESSION and TPM_HT_HMAC_SESSION have the same
value, as do TPM_HT_SAVED_SESSION and TPM_HT_POLICY_SESSION, but they
are used in different context.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>