### PR TITLE
tpm2_unseal: make -F optional to allow using current PCR values for auth

### DIFF
--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -60,7 +60,6 @@ struct tpm_unseal_ctx {
         UINT8 c : 1;
         UINT8 P : 1;
         UINT8 L : 1;
-        UINT8 F : 1;
     } flags;
 };
 
@@ -118,7 +117,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
         }
     }
 
-    if (ctx.flags.L && ctx.flags.F) {
+    if (ctx.flags.L) {
         TPM2B_DIGEST pcr_digest = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
 
         TPM_RC rval = tpm2_policy_build(sapi_context, &ctx.policy_session,
@@ -184,7 +183,6 @@ static bool on_option(char key, char *value) {
         break;
     case 'F':
         ctx.raw_pcrs_file = optarg;
-        ctx.flags.F = 1;
         break;
         /* no default */
     }


### PR DESCRIPTION
The tool currently checks if both the -L and -F options were defined and
only builds a PCR policy session for authentication if that's the case.

But the tpm2_unseal man page says that the -F option is not required, if
this isn't defined then the current PCR values are used to build the PCR
policy used for authorization to unseal the data.

So honor the man page says and don't make the -F option to be required,
instead just always pass raw_pcrs_file to tpm2_policy_build(). If it's
NULL, then this function reads the current PCR values instead of trying
to use the values that are defined in a file.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>