### PR TITLE
configure: fix check for bash shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,9 +167,9 @@ AS_IF([test x"$strip" == x"yyy"], [
   AC_MSG_NOTICE([Not using compiler options to reduce binary size!])
 )
 
-AC_CHECK_PROG([BASH],[bash],[yes])
+AC_CHECK_PROG([BASH_SHELL],[bash],[yes])
 AS_IF(
-    [test "x${BASH}" == x"yes"],
+    [test "x${BASH_SHELL}" == x"yes"],
     [],
     [AC_MSG_WARN([Required executable bash not found, system tests require a bash shell!])])
 


### PR DESCRIPTION
The bash shell sets the BASH variable with the full path name used to
execute the current instance of bash. But the configure script uses it
to attempt to check if the bash binary is present on a given system.

The configure script uses the #!/bin/sh shebang, so on a system where
/bin/sh is the bash shell, the configure script will fail to find the
bash binary due BASH being set to /bin/sh:

checking for bash... /bin/sh
configure: WARNING: Required executable bash not found, system tests require a bash shell!

Use instead a variable name that isn't an internal one used by bash.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>